### PR TITLE
Rewrite SubScan: iterate RGs with direct REST for reliable phantom detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 1. **set-storage-account-content-headers.ps1**: Sets Azure static website files content headers (such as Content-Type or Cache-Control).
 1. **register-preview-features.ps1**: Manages Azure preview feature flags. Lists, registers, unregisters, and exports feature states.
-1. **find-phantom-resource.ps1**: Finds hidden/phantom resources blocking resource group deletion. Uses the ARM REST API directly, which bypasses the case-sensitive JMESPath filtering that causes `az network * list` to miss resources. Also checks NICs, subnets, private endpoints, DNS zones, NSGs, load balancers, route tables, managedBy resources, and failed deployments. Usage: `pwsh find-phantom-resource.ps1 -ResourceGroup "MyRG"`
+1. **find-phantom-resource.ps1**: Finds and deletes hidden/phantom resources blocking resource group deletion. Uses ARM REST API directly to bypass JMESPath case-sensitivity bugs. Single-RG mode (`-ResourceGroup`) or subscription-wide scan (`-SubScan [-Region X]`). Supports `-Delete -Force` to remove orphaned phantoms and `-DeleteResourceGroup` to clean up the RG afterward. Usage: `pwsh find-phantom-resource.ps1 -ResourceGroup "MyRG"` or `pwsh find-phantom-resource.ps1 -SubScan -Region "centralindia"`
 1. **azure-swap.bash**: A tool that looks for local temporary disk and creates a swap file of 90% of that storage, leaving 10% available. It creates an autostart service in case Azure removes the disk when the machine is stopped.
 
 ## Details
@@ -214,21 +214,40 @@ A collection of Python and PowerShell utilities for Azure cost optimization, mon
    - **Force Overwrite**: Use `-ForceOverwrite` switch to suppress interactive prompts when overwriting existing resources (useful for automation).
    - **Infrastructure-Only Mode**: Use `-CreateInfrastructureOnly` with `-UseNatGateway` to create only shared infrastructure (RG, VNet, NAT Gateway) without VMs. Returns JSON with resource details. Useful for multi-worker orchestration where infrastructure should be created once before spawning parallel workers.
 
-3. **find-phantom-resource.ps1**: Find hidden/phantom resources blocking resource group deletion
-   - Problem: Azure Portal shows resources (Public IPs, VNets) in a resource group, but `az resource list`, `az network public-ip list`, and `az network vnet list` all return empty. The resource group cannot be deleted.
-   - Root Cause: `az network * list --query "[?resourceGroup=='X']"` uses JMESPath client-side filtering, which is case-sensitive. Azure stores resource group names with inconsistent casing internally (e.g., "FishtestSpotRG-9" in the portal vs "FISHTESTSPOTRG-9" in the backend). When casing differs, JMESPath silently returns zero results.
-   - Solution: The script uses `az rest --method GET` to query the ARM REST API directly by resource group path. This bypasses JMESPath entirely and always returns all resources regardless of internal casing.
-   - Also checks: NICs, subnets, private endpoints, private DNS zones, load balancers, route tables, NSGs, managedBy orphans, and failed deployments.
-   - Common with Spot VMs where eviction or failed provisioning leaves orphaned network resources.
+3. **find-phantom-resource.ps1**: Find and delete hidden/phantom resources blocking resource group deletion, with subscription-wide scan support
+   - **Problem**: Azure Portal shows resources (Public IPs, VNets, NICs) in a resource group, but `az resource list` and `az network * list` all return empty. The resource group cannot be deleted. Also handles 409 Conflict errors when recreating resources that Azure claims still exist but are invisible.
+   - **Root Cause**: `az network * list --query "[?resourceGroup=='X']"` uses JMESPath client-side filtering, which is case-sensitive. Azure stores resource group names with inconsistent internal casing (e.g., "FishtestSpotRG-9" in the portal vs "FISHTESTSPOTRG-9" in the backend). When casing differs, JMESPath silently returns zero results. Azure Resource Graph also does not index these phantom resources, so `az graph query` misses them too.
+   - **Solution**: Uses `az rest --method GET /resourceGroups/{RG}/resources` to query the ARM REST API directly by resource group path. This bypasses JMESPath entirely and returns all resources regardless of internal casing, including resources invisible to all other query methods.
+   - **Also checks**: NICs, subnets, private endpoints, private DNS zones, load balancers, route tables, NSGs, managedBy orphans, and failed deployments.
+   - **Common cause**: Spot VM eviction or failed provisioning (especially region-change deployments) leaves orphaned network resources and OS disks in a stale location.
+   - **Two operating modes**:
+     - `-ResourceGroup`: scan a single known RG (fast, targeted)
+     - `-SubScan`: iterate all RGs in the subscription (or only RGs in `-Region`) and run the direct REST scan on each - catches phantoms across the subscription without knowing which RG to look in
    - Usage:
 
      ```powershell
-     # Find phantom resources
+     # Scan a specific resource group for phantom resources
      pwsh find-phantom-resource.ps1 -ResourceGroup "FishtestSpotRG-9"
 
-     # Delete found resources by ID, then delete the resource group
-     az resource delete --ids "/subscriptions/.../providers/Microsoft.Network/publicIPAddresses/my-pip"
-     az group delete -n "FishtestSpotRG-9" --yes
+     # Preview which phantom resources are safe to delete
+     pwsh find-phantom-resource.ps1 -ResourceGroup "FishtestSpotRG-9" -DryRun
+
+     # Delete orphaned phantom resources (safe types only: NICs, disks, PIPs, VNets, NSGs...)
+     pwsh find-phantom-resource.ps1 -ResourceGroup "FishtestSpotRG-9" -Delete -Force
+
+     # Delete orphaned phantom resources and then delete the resource group
+     pwsh find-phantom-resource.ps1 -ResourceGroup "FishtestSpotRG-9" -Delete -Force -DeleteResourceGroup
+
+     # Subscription-wide scan: find phantoms in all RGs located in centralindia
+     pwsh find-phantom-resource.ps1 -SubScan -Region "centralindia"
+
+     # Subscription-wide scan: all RGs in the subscription (use when RG region may differ from resource region)
+     pwsh find-phantom-resource.ps1 -SubScan
+
+     # Delete a phantom resource found by SubScan (use az rest, not az resource delete)
+     az rest --method DELETE --url "https://management.azure.com/subscriptions/.../resourceGroups/MyRG/providers/Microsoft.Network/networkInterfaces/my-nic?api-version=2024-01-01"
+     az rest --method DELETE --url "https://management.azure.com/subscriptions/.../resourceGroups/MyRG/providers/Microsoft.Compute/disks/my-osdisk?api-version=2024-03-02"
+     az group delete -n "MyRG" --yes
      ```
 
 4. **set-storage-account-content-headers.ps1**: Static website optimization and deployment

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 1. **set-storage-account-content-headers.ps1**: Sets Azure static website files content headers (such as Content-Type or Cache-Control).
 1. **register-preview-features.ps1**: Manages Azure preview feature flags. Lists, registers, unregisters, and exports feature states.
-1. **find-phantom-resource.ps1**: Finds and deletes hidden/phantom resources blocking resource group deletion. Uses ARM REST API directly to bypass JMESPath case-sensitivity bugs. Single-RG mode (`-ResourceGroup`) or subscription-wide scan (`-SubScan [-Region X]`). Supports `-Delete -Force` to remove orphaned phantoms and `-DeleteResourceGroup` to clean up the RG afterward. Usage: `pwsh find-phantom-resource.ps1 -ResourceGroup "MyRG"` or `pwsh find-phantom-resource.ps1 -SubScan -Region "centralindia"`
+1. **find-phantom-resource.ps1**: Finds and deletes hidden/phantom resources blocking resource group deletion. Uses ARM REST API directly to bypass JMESPath case-sensitivity bugs. Modes: single-RG (`-ResourceGroup`, supports `-Delete -Force` and optional `-DeleteResourceGroup`) or subscription-wide scan (`-SubScan [-Region X]`, scan-only). Usage: `pwsh find-phantom-resource.ps1 -ResourceGroup "MyRG"` or `pwsh find-phantom-resource.ps1 -SubScan -Region "centralindia"`
 1. **azure-swap.bash**: A tool that looks for local temporary disk and creates a swap file of 90% of that storage, leaving 10% available. It creates an autostart service in case Azure removes the disk when the machine is stopped.
 
 ## Details
@@ -217,7 +217,7 @@ A collection of Python and PowerShell utilities for Azure cost optimization, mon
 3. **find-phantom-resource.ps1**: Find and delete hidden/phantom resources blocking resource group deletion, with subscription-wide scan support
    - **Problem**: Azure Portal shows resources (Public IPs, VNets, NICs) in a resource group, but `az resource list` and `az network * list` all return empty. The resource group cannot be deleted. Also handles 409 Conflict errors when recreating resources that Azure claims still exist but are invisible.
    - **Root Cause**: `az network * list --query "[?resourceGroup=='X']"` uses JMESPath client-side filtering, which is case-sensitive. Azure stores resource group names with inconsistent internal casing (e.g., "FishtestSpotRG-9" in the portal vs "FISHTESTSPOTRG-9" in the backend). When casing differs, JMESPath silently returns zero results. Azure Resource Graph also does not index these phantom resources, so `az graph query` misses them too.
-   - **Solution**: Uses `az rest --method GET /resourceGroups/{RG}/resources` to query the ARM REST API directly by resource group path. This bypasses JMESPath entirely and returns all resources regardless of internal casing, including resources invisible to all other query methods.
+   - **Solution**: Uses `az rest --method GET /subscriptions/{subscriptionId}/resourceGroups/{RG}/resources` to query the ARM REST API directly. This bypasses JMESPath entirely and returns all resources regardless of internal casing, including resources invisible to all other query methods.
    - **Also checks**: NICs, subnets, private endpoints, private DNS zones, load balancers, route tables, NSGs, managedBy orphans, and failed deployments.
    - **Common cause**: Spot VM eviction or failed provisioning (especially region-change deployments) leaves orphaned network resources and OS disks in a stale location.
    - **Two operating modes**:

--- a/find-phantom-resource.ps1
+++ b/find-phantom-resource.ps1
@@ -400,6 +400,7 @@ if ($SubScan) {
 
     $allPhantoms  = [System.Collections.Generic.List[object]]::new()
     $deletingRGs  = [System.Collections.Generic.List[object]]::new()
+    $skippedRGs   = [System.Collections.Generic.List[string]]::new()
     $scannedCount = 0
 
     foreach ($rg in $rgList) {
@@ -416,6 +417,9 @@ if ($SubScan) {
         # Direct REST scan - same reliable method as single-RG mode.
         # Bypasses JMESPath casing bug and finds phantoms invisible to az resource list.
         # Paginates via nextLink so large RGs are fully covered.
+        # No secondary resource-location filter: the RG list was already scoped to
+        # -Region, so all resources in those RGs are relevant regardless of their
+        # individual location field.
         $items = [System.Collections.Generic.List[object]]::new()
         $nextUrl = "/subscriptions/$subscriptionId/resourceGroups/$rgName/resources?api-version=2024-03-01"
         $restFailed = $false
@@ -423,6 +427,7 @@ if ($SubScan) {
             $restResult = Invoke-AzRest -Url $nextUrl
             if ($null -eq $restResult -or $null -eq $restResult.value) {
                 Write-Host " (REST failed, skipped)"
+                $skippedRGs.Add("$rgName (REST)")
                 $restFailed = $true
                 break
             }
@@ -431,12 +436,7 @@ if ($SubScan) {
         }
         if ($restFailed) { continue }
 
-        # Filter by resource location if -Region specified.
-        if ($Region) {
-            $items = $items | Where-Object { $_.location -ieq $Region }
-        }
-
-        if ($null -eq $items -or $items.Count -eq 0) {
+        if ($items.Count -eq 0) {
             Write-Host " (no resources)"
             continue
         }
@@ -447,6 +447,7 @@ if ($SubScan) {
         $azListJson = az resource list -g $rgName -o json --only-show-errors 2>&1
         if ($LASTEXITCODE -ne 0) {
             Write-Host " (az resource list failed, skipped)"
+            $skippedRGs.Add("$rgName (az resource list)")
             continue
         }
         $azIds = @{}
@@ -455,6 +456,7 @@ if ($SubScan) {
             foreach ($r in $azParsed) { $azIds[$r.id.ToLower()] = $true }
         } catch {
             Write-Warning "Failed to parse 'az resource list' for '$rgName'. Phantom detection skipped for this RG."
+            $skippedRGs.Add("$rgName (az resource list parse)")
             continue
         }
 
@@ -504,6 +506,15 @@ if ($SubScan) {
         Write-Host "  To delete via REST:" -ForegroundColor Cyan
         Write-Host "    az rest --method DELETE --url 'https://management.azure.com/<full-resource-id>?api-version=...'" -ForegroundColor Cyan
         Write-Host "    where <full-resource-id> starts with /subscriptions/..." -ForegroundColor Cyan
+    }
+
+    if ($skippedRGs.Count -gt 0) {
+        Write-Warning "Scan incomplete - the following RG(s) were skipped due to errors:"
+        foreach ($s in $skippedRGs) {
+            Write-Warning "  $s"
+        }
+        Write-Host "`nPartial scan complete. Scanned $scannedCount RG(s), skipped $($skippedRGs.Count)." -ForegroundColor Yellow
+        exit 2
     }
 
     Write-Host "`nScan complete. Scanned $scannedCount RG(s)." -ForegroundColor Green

--- a/find-phantom-resource.ps1
+++ b/find-phantom-resource.ps1
@@ -373,18 +373,20 @@ if ($SubScan) {
     Write-Host "Subscription: $subscriptionId`n"
 
     # List resource groups, optionally filtered by location.
+    # JMESPath location== is case-sensitive, so fetch all RGs and filter in PowerShell
+    # with -ieq to handle mixed-case input (e.g. "CentralIndia" vs "centralindia").
     # Note: -Region filters by RG location. Resources in the target region whose
     # RG is located elsewhere require running without -Region to be found.
     Write-Host "  Listing resource groups..." -NoNewline
-    $rgQuery = if ($Region) { "[?location=='$Region']" } else { "[]" }
-    $rgListJson = az group list --query $rgQuery -o json --only-show-errors 2>&1
+    $rgListJson = az group list -o json --only-show-errors 2>&1
     if ($LASTEXITCODE -ne 0) {
         Write-Host " FAILED" -ForegroundColor Red
         Write-Host "ERROR: az group list failed. Check authentication." -ForegroundColor Red
         exit 1
     }
     try {
-        $rgList = $rgListJson | ConvertFrom-Json
+        $rgListAll = $rgListJson | ConvertFrom-Json
+        $rgList = if ($Region) { @($rgListAll | Where-Object { $_.location -ieq $Region }) } else { $rgListAll }
     } catch {
         Write-Host " FAILED (parse error: $_)" -ForegroundColor Red
         exit 1
@@ -413,12 +415,21 @@ if ($SubScan) {
 
         # Direct REST scan - same reliable method as single-RG mode.
         # Bypasses JMESPath casing bug and finds phantoms invisible to az resource list.
-        $restResult = Invoke-AzRest -Url "/subscriptions/$subscriptionId/resourceGroups/$rgName/resources?api-version=2024-03-01"
-        if ($null -eq $restResult -or $null -eq $restResult.value) {
-            Write-Host " (REST failed, skipped)"
-            continue
+        # Paginates via nextLink so large RGs are fully covered.
+        $items = [System.Collections.Generic.List[object]]::new()
+        $nextUrl = "/subscriptions/$subscriptionId/resourceGroups/$rgName/resources?api-version=2024-03-01"
+        $restFailed = $false
+        while ($nextUrl) {
+            $restResult = Invoke-AzRest -Url $nextUrl
+            if ($null -eq $restResult -or $null -eq $restResult.value) {
+                Write-Host " (REST failed, skipped)"
+                $restFailed = $true
+                break
+            }
+            foreach ($item in $restResult.value) { $items.Add($item) }
+            $nextUrl = $restResult.nextLink
         }
-        $items = $restResult.value
+        if ($restFailed) { continue }
 
         # Filter by resource location if -Region specified.
         if ($Region) {
@@ -431,13 +442,20 @@ if ($SubScan) {
         }
 
         # az resource list for comparison - may miss phantoms due to casing mismatch.
+        # Skip this RG if az resource list fails or parse fails: an empty baseline
+        # would flag every REST-visible resource as phantom (false positives).
         $azListJson = az resource list -g $rgName -o json --only-show-errors 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host " (az resource list failed, skipped)"
+            continue
+        }
         $azIds = @{}
-        if ($LASTEXITCODE -eq 0) {
-            try {
-                $azParsed = $azListJson | ConvertFrom-Json
-                foreach ($r in $azParsed) { $azIds[$r.id.ToLower()] = $true }
-            } catch {}
+        try {
+            $azParsed = $azListJson | ConvertFrom-Json
+            foreach ($r in $azParsed) { $azIds[$r.id.ToLower()] = $true }
+        } catch {
+            Write-Warning "Failed to parse 'az resource list' for '$rgName'. Phantom detection skipped for this RG."
+            continue
         }
 
         # Find phantoms: in direct REST but not in az resource list.
@@ -484,7 +502,8 @@ if ($SubScan) {
         }
         Write-Host ""
         Write-Host "  To delete via REST:" -ForegroundColor Cyan
-        Write-Host "    az rest --method DELETE --url 'https://management.azure.com<ID>?api-version=...'" -ForegroundColor Cyan
+        Write-Host "    az rest --method DELETE --url 'https://management.azure.com/<full-resource-id>?api-version=...'" -ForegroundColor Cyan
+        Write-Host "    where <full-resource-id> starts with /subscriptions/..." -ForegroundColor Cyan
     }
 
     Write-Host "`nScan complete. Scanned $scannedCount RG(s)." -ForegroundColor Green

--- a/find-phantom-resource.ps1
+++ b/find-phantom-resource.ps1
@@ -24,8 +24,15 @@
       5. Subscription-wide scan for resources with managedBy field
       6. Failed deployments in the resource group
 
-    With -SubScan: subscription-wide scan for resources in a region whose
-    resource group does not exist or is in "Deleting" state.
+    With -SubScan: iterates all resource groups in the subscription (optionally
+    filtered by -Region), runs the direct REST scan on each, and reports:
+      - Phantom resources: visible via ARM REST but invisible to az resource list
+      - Deleting RGs: resource groups stuck in the Deleting state
+
+    This catches the same class of phantom resources as the single-RG mode but
+    across the entire subscription. The -Region filter restricts which RGs are
+    scanned (by RG location). Resources in the target region whose RG is located
+    in a different region require running -SubScan without -Region.
 
 .PARAMETER ResourceGroup
     Name of the Azure resource group to scan. Required unless -SubScan is used.
@@ -56,13 +63,15 @@
     itself. Requires -Delete and -Force.
 
 .PARAMETER SubScan
-    Subscription-wide scan mode. Finds resources whose resource group does not
-    exist or is in "Deleting" state. Use with -Region to filter by location.
+    Subscription-wide phantom scan. Iterates all RGs (or only RGs in -Region)
+    and applies the same direct REST scan as -ResourceGroup mode to each one.
+    Reports phantom resources and RGs in Deleting state.
     Cannot be combined with -ResourceGroup.
 
 .PARAMETER Region
-    Azure region name (e.g. "centralindia") to filter resources in -SubScan mode.
-    Without this, all regions are scanned (slow).
+    Azure region name (e.g. "centralindia"). In -SubScan mode: restricts scan
+    to RGs located in this region and further filters resources by this location.
+    Without -Region, all RGs in the subscription are scanned.
 
 .EXAMPLE
     pwsh find-phantom-resource.ps1 -ResourceGroup "FishtestSpotRG-10"
@@ -87,7 +96,13 @@
 .EXAMPLE
     pwsh find-phantom-resource.ps1 -SubScan -Region "centralindia"
 
-    Finds all resources in centralindia whose resource group is missing or stuck.
+    Scans all RGs in centralindia for phantom resources and Deleting RGs.
+
+.EXAMPLE
+    pwsh find-phantom-resource.ps1 -SubScan
+
+    Scans all RGs in the subscription for phantom resources. Use when the
+    target resource may be in a region that differs from its RG location.
 
 .NOTES
     Requires: Azure CLI (az) authenticated and with an active subscription.
@@ -344,7 +359,7 @@ function Test-ResourceOrphaned {
 }
 
 # ============================================================
-# SUBSCAN MODE: subscription-wide orphan search by region
+# SUBSCAN MODE: subscription-wide phantom scan per RG
 # ============================================================
 if ($SubScan) {
     $subscriptionId = az account show --query id -o tsv
@@ -354,91 +369,125 @@ if ($SubScan) {
     }
 
     $regionLabel = if ($Region) { $Region } else { "all regions" }
-    Write-Host "Subscription-wide orphan scan: $regionLabel" -ForegroundColor Cyan
+    Write-Host "Subscription-wide phantom scan: $regionLabel" -ForegroundColor Cyan
     Write-Host "Subscription: $subscriptionId`n"
 
-    # Use Azure Resource Graph for reliable subscription-wide query.
-    # The ARM REST $filter=location is known to return incomplete results.
-    # Resource Graph requires the resource-graph extension: az extension add --name resource-graph
-    $allResources = [System.Collections.Generic.List[object]]::new()
-    $locationFilter = if ($Region) { "| where location == '$Region'" } else { "" }
-    $kqlQuery = "Resources $locationFilter | project id, name, type, location, resourceGroup"
-    Write-Host "  Running Resource Graph query..."
-    $graphJson = az graph query -q $kqlQuery --output json --only-show-errors 2>&1
+    # List resource groups, optionally filtered by location.
+    # Note: -Region filters by RG location. Resources in the target region whose
+    # RG is located elsewhere require running without -Region to be found.
+    Write-Host "  Listing resource groups..." -NoNewline
+    $rgQuery = if ($Region) { "[?location=='$Region']" } else { "[]" }
+    $rgListJson = az group list --query $rgQuery -o json --only-show-errors 2>&1
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "ERROR: Resource Graph query failed: $graphJson" -ForegroundColor Red
-        Write-Host "Ensure the resource-graph extension is installed: az extension add --name resource-graph" -ForegroundColor Yellow
+        Write-Host " FAILED" -ForegroundColor Red
+        Write-Host "ERROR: az group list failed. Check authentication." -ForegroundColor Red
         exit 1
     }
     try {
-        $graphResult = $graphJson | ConvertFrom-Json
-        $items = $graphResult.data
-        if ($null -ne $items) {
-            foreach ($item in $items) { $allResources.Add($item) }
-        }
+        $rgList = $rgListJson | ConvertFrom-Json
     } catch {
-        Write-Host "ERROR: Failed to parse Resource Graph response: $_" -ForegroundColor Red
+        Write-Host " FAILED (parse error: $_)" -ForegroundColor Red
         exit 1
     }
+    Write-Host " $($rgList.Count) found"
 
-    Write-Host "  Total resources retrieved: $($allResources.Count)`n"
-
-    if ($allResources.Count -eq 0) {
-        Write-Host "No resources found for the specified filter." -ForegroundColor Yellow
+    if ($rgList.Count -eq 0) {
+        Write-Host "No resource groups found for the specified filter." -ForegroundColor Yellow
         exit 0
     }
 
-    # Cache RG status to avoid redundant queries
-    $rgStatusCache = @{}
+    $allPhantoms  = [System.Collections.Generic.List[object]]::new()
+    $deletingRGs  = [System.Collections.Generic.List[object]]::new()
+    $scannedCount = 0
 
-    function Get-RgStatus {
-        param([string]$RgName)
-        $key = $RgName.ToLower()
-        if ($rgStatusCache.ContainsKey($key)) {
-            return $rgStatusCache[$key]
-        }
-        $rgData = Invoke-AzRest -Url "/subscriptions/$subscriptionId/resourceGroups/$RgName`?api-version=2021-04-01"
-        if ($null -eq $rgData) {
-            $rgStatusCache[$key] = "NotFound"
-            return "NotFound"
-        }
-        $state = $rgData.properties.provisioningState
-        $rgStatusCache[$key] = $state
-        return $state
-    }
+    foreach ($rg in $rgList) {
+        $rgName  = $rg.name
+        $rgState = $rg.properties.provisioningState
+        $scannedCount++
 
-    # Check each resource's RG
-    $orphanedResources = [System.Collections.Generic.List[object]]::new()
-    foreach ($r in $allResources) {
-        $rgName = $r.resourceGroup
-        if ([string]::IsNullOrWhiteSpace($rgName)) {
+        Write-Host "  [$scannedCount/$($rgList.Count)] $rgName ($rgState)..." -NoNewline
+
+        if ($rgState -eq "Deleting") {
+            $deletingRGs.Add($rg)
+        }
+
+        # Direct REST scan - same reliable method as single-RG mode.
+        # Bypasses JMESPath casing bug and finds phantoms invisible to az resource list.
+        $restResult = Invoke-AzRest -Url "/subscriptions/$subscriptionId/resourceGroups/$rgName/resources?api-version=2024-03-01"
+        if ($null -eq $restResult -or $null -eq $restResult.value) {
+            Write-Host " (REST failed, skipped)"
             continue
         }
-        $rgStatus = Get-RgStatus -RgName $rgName
-        if ($rgStatus -eq "NotFound" -or $rgStatus -eq "Deleting") {
-            $orphanedResources.Add([PSCustomObject]@{
-                Name          = $r.name
-                Type          = $r.type
-                Location      = $r.location
-                ResourceGroup = $rgName
-                RgStatus      = $rgStatus
-                Id            = $r.id
-            })
+        $items = $restResult.value
+
+        # Filter by resource location if -Region specified.
+        if ($Region) {
+            $items = $items | Where-Object { $_.location -ieq $Region }
         }
+
+        if ($null -eq $items -or $items.Count -eq 0) {
+            Write-Host " (no resources)"
+            continue
+        }
+
+        # az resource list for comparison - may miss phantoms due to casing mismatch.
+        $azListJson = az resource list -g $rgName -o json --only-show-errors 2>&1
+        $azIds = @{}
+        if ($LASTEXITCODE -eq 0) {
+            try {
+                $azParsed = $azListJson | ConvertFrom-Json
+                foreach ($r in $azParsed) { $azIds[$r.id.ToLower()] = $true }
+            } catch {}
+        }
+
+        # Find phantoms: in direct REST but not in az resource list.
+        $rgPhantoms = 0
+        foreach ($r in $items) {
+            if (-not $azIds.ContainsKey($r.id.ToLower())) {
+                $allPhantoms.Add([PSCustomObject]@{
+                    Name          = $r.name
+                    Type          = $r.type
+                    Location      = $r.location
+                    ResourceGroup = $rgName
+                    RgStatus      = $rgState
+                    Id            = $r.id
+                })
+                $rgPhantoms++
+            }
+        }
+
+        $phantomNote = if ($rgPhantoms -gt 0) { " [$rgPhantoms PHANTOM]" } else { "" }
+        Write-Host " $($items.Count) resource(s)$phantomNote"
     }
 
-    if ($orphanedResources.Count -eq 0) {
-        Write-Host "No orphaned resources found (all resource groups active)." -ForegroundColor Green
-    } else {
-        Write-Host "=== Orphaned Resources (RG missing or in Deleting state) ===" -ForegroundColor Yellow
-        Write-Host "  Found $($orphanedResources.Count) orphaned resource(s):`n" -ForegroundColor Yellow
-        $orphanedResources | Format-Table Name, Type, Location, ResourceGroup, RgStatus -AutoSize
-        Write-Host "`n  Resource IDs:" -ForegroundColor Yellow
-        foreach ($o in $orphanedResources) {
-            Write-Host "    [$($o.RgStatus)] $($o.Id)"
+    Write-Host ""
+
+    # Report Deleting RGs
+    if ($deletingRGs.Count -gt 0) {
+        Write-Host "=== Resource Groups in Deleting State ===" -ForegroundColor Yellow
+        foreach ($rg in $deletingRGs) {
+            Write-Host "  [DELETING] $($rg.name) ($($rg.location))" -ForegroundColor Yellow
         }
+        Write-Host ""
     }
-    Write-Host "`nScan complete." -ForegroundColor Green
+
+    # Report phantom resources
+    if ($allPhantoms.Count -eq 0) {
+        Write-Host "No phantom resources found." -ForegroundColor Green
+    } else {
+        Write-Host "=== Phantom Resources (invisible to 'az resource list') ===" -ForegroundColor Yellow
+        Write-Host "  Found $($allPhantoms.Count) phantom resource(s):" -ForegroundColor Yellow
+        $allPhantoms | Format-Table Name, Type, Location, ResourceGroup, RgStatus -AutoSize
+        Write-Host "  Resource IDs:" -ForegroundColor Yellow
+        foreach ($p in $allPhantoms) {
+            Write-Host "    [$($p.RgStatus)] $($p.Id)"
+        }
+        Write-Host ""
+        Write-Host "  To delete via REST:" -ForegroundColor Cyan
+        Write-Host "    az rest --method DELETE --url 'https://management.azure.com<ID>?api-version=...'" -ForegroundColor Cyan
+    }
+
+    Write-Host "`nScan complete. Scanned $scannedCount RG(s)." -ForegroundColor Green
     exit 0
 }
 


### PR DESCRIPTION
## Summary

- Replace Resource Graph-based SubScan with per-RG direct ARM REST scan (same method as single-RG mode)
- SubScan now iterates all resource groups (filtered by -Region if specified), queries each via GET /resourceGroups/{rg}/resources, and compares against az resource list to find phantoms
- Detects and reports resource groups in Deleting state as a separate category
- Removes dependency on the resource-graph az extension
- Updates README with full -SubScan documentation, -Delete/-DryRun/-Force mode docs, and az rest DELETE examples for phantom cleanup

## Why the previous approach failed

Azure Resource Graph does not index phantom resources (invisible to az resource list due to JMESPath casing bugs). When fishtest-spot-15-nic was a phantom in FishtestSpotRG-15, neither Resource Graph nor the ARM filter-by-location API returned it. Only the direct per-RG REST endpoint GET /resourceGroups/{rg}/resources reveals these resources, bypassing all caching and client-side filtering.

## Test plan

- SubScan -Region newzealandnorth: scanned 15 RGs, found 2 Deleting RGs, no false positives
- SubScan -Region centralindia: correctly reported 0 RGs after FishtestSpotRG-15 cleanup
- SubScan (no region): runs against all RGs in the subscription
- Single-RG mode (-ResourceGroup) unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README with comprehensive usage examples, two operating modes (single-RG and subscription-wide with optional region), dry-run previews, and deletion guidance.

* **New Features**
  * Subscription-wide scan reworked to enumerate per-resource-group results with optional region scoping.
  * REST-based enumeration and expanded checks (NICs, subnets, private endpoints, DNS zones, load balancers, route tables, NSGs, orphaned deployments).
  * Improved reporting: per-RG progress, phantom listings, counts, RG status, and partial-scan summaries.

* **Bug Fixes**
  * Better handling of recreate conflicts, case-sensitive filtering issues, and phantom resources invisible to standard queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->