### PR TITLE
Enrich scripts with Azure Skills reference features and add orphan scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ## VM Provisioning
 
 1. **create-spot-vms.ps1**: Creates Azure Spot VMs with any Linux image (Ubuntu by default). Supports full ARM64, dynamic Ubuntu image discovery, NAT Gateway, and custom images via `-ImagePublisher`/`-ImageOffer`/`-ImageSku` for any Linux distro. Supports `-UseLTS` with `-LTSOffset` for older LTS selection.
-1. **create-192core-vm.ps1**: Creates a 192-core Azure Spot VM. Auto-finds cheapest VM size and region, checks quota in 40 regions before querying prices, excludes restricted regions. Shows progress indicator.
+1. **create-192core-vm.ps1**: Wrapper script that orchestrates vm-spot-price.py and create-spot-vms.ps1 to create a 192-core Azure Spot VM. Uses vm-spot-price.py to auto-find the cheapest VM size and region, checks quota in 40 regions before querying prices, excludes restricted regions, then calls create-spot-vms.ps1 to provision the VM. Shows progress indicator. Supports `-WhatIf` for dry run.
 
 ## Infrastructure Management
 

--- a/blob-storage-price.py
+++ b/blob-storage-price.py
@@ -303,6 +303,35 @@ Security Notes:
 
     parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
 
+    parser.add_argument(
+        "--access-tier",
+        choices=["hot", "cool", "cold", "archive"],
+        default=None,
+        help="Filter by blob access tier (hot, cool, cold, archive)",
+    )
+
+    parser.add_argument(
+        "--redundancy",
+        choices=["LRS", "ZRS", "GRS", "GZRS", "RA-GRS", "RA-GZRS"],
+        default=None,
+        help="Filter by redundancy type (e.g., LRS, ZRS, GRS)",
+    )
+
+    parser.add_argument(
+        "--estimate-monthly",
+        type=float,
+        default=None,
+        metavar="TB",
+        help="Show estimated monthly cost for specified TB of storage",
+    )
+
+    parser.add_argument(
+        "--currency",
+        type=str,
+        default=None,
+        help="Currency code for pricing (e.g., EUR, GBP). Default: USD",
+    )
+
     args = parser.parse_args()
 
     # Validate timeout
@@ -325,9 +354,23 @@ Security Notes:
         product_filter = " or ".join(
             f"productName eq '{blob_type}'" for blob_type in escaped_types
         )
-        params = {
-            "$filter": f"({product_filter}) and priceType eq 'Consumption' and serviceName eq 'Storage'"
-        }
+        api_filter = f"({product_filter}) and priceType eq 'Consumption' and serviceName eq 'Storage'"
+        if args.access_tier:
+            tier_map = {
+                "hot": "Hot",
+                "cool": "Cool",
+                "cold": "Cold",
+                "archive": "Archive",
+            }
+            api_filter += f" and contains(skuName, '{tier_map[args.access_tier]}')"
+        if args.redundancy:
+            api_filter += f" and contains(skuName, '{args.redundancy}')"
+        params = {"$filter": api_filter}
+        if args.currency:
+            if not args.currency.isalpha() or len(args.currency) != 3:
+                print("Error: Currency must be a 3-letter ISO 4217 code (e.g., EUR, GBP)", file=sys.stderr)
+                sys.exit(1)
+            params["currencyCode"] = args.currency
     except Exception as e:
         print(f"Error building API filter: {e}", file=sys.stderr)
         sys.exit(1)
@@ -457,26 +500,45 @@ def format_output(
     region_avg_prices: List[Tuple[str, float]],
     excluded_regions: Set[str],
     output_format: str,
+    estimate_tb: Optional[float] = None,
+    currency: Optional[str] = None,
 ) -> None:
     """Format and print the results in the specified format."""
+    currency_label = currency if currency else "USD"
 
     if output_format == "json":
         # JSON output
-        result = {
-            "blob_types": blob_types,
-            "region_prices": [
+        if estimate_tb is not None:
+            region_data = [
+                {
+                    "region": region,
+                    "avg_price": price,
+                    "monthly_estimate": round(price * estimate_tb * 1024, 2),
+                }
+                for region, price in region_avg_prices
+            ]
+        else:
+            region_data = [
                 {"region": region, "avg_price": price}
                 for region, price in region_avg_prices
-            ],
+            ]
+        result = {
+            "blob_types": blob_types,
+            "region_prices": region_data,
             "excluded_regions": list(excluded_regions),
         }
         print(json.dumps(result, indent=2))
 
     elif output_format == "csv":
         # CSV output
-        print("Region,Average_Price_USD")
-        for region, price in region_avg_prices:
-            print(f"{region},{price:.6f}")
+        if estimate_tb is not None:
+            print(f"Region,Average_Price_{currency_label},Monthly_Estimate_{estimate_tb}TB")
+            for region, price in region_avg_prices:
+                print(f"{region},{price:.6f},{price * estimate_tb * 1024:.2f}")
+        else:
+            print(f"Region,Average_Price_{currency_label}")
+            for region, price in region_avg_prices:
+                print(f"{region},{price:.6f}")
 
     else:
         # Table output (default)
@@ -493,10 +555,17 @@ def format_output(
             else f"Blob storage service ({blob_types[0]}) price per region"
         )
         print("\n" + table_caption)
-        headers = ["Region", "Average Price (USD)"]
-        formatted_data = [
-            (region, f"{price:.6f}") for region, price in region_avg_prices
-        ]
+        if estimate_tb is not None:
+            headers = ["Region", f"Avg Price/GB ({currency_label})", f"Est. {currency_label}/Month ({estimate_tb} TB)"]
+            formatted_data = [
+                (region, f"{price:.6f}", f"{price * estimate_tb * 1024:.2f}")
+                for region, price in region_avg_prices
+            ]
+        else:
+            headers = ["Region", f"Average Price ({currency_label})"]
+            formatted_data = [
+                (region, f"{price:.6f}") for region, price in region_avg_prices
+            ]
         print(tabulate(formatted_data, headers=headers, tablefmt="psql"))
 
 
@@ -545,7 +614,9 @@ def main() -> None:
 
         # Output results
         format_output(
-            blob_types, region_avg_prices, excluded_regions, args.output_format
+            blob_types, region_avg_prices, excluded_regions, args.output_format,
+            estimate_tb=args.estimate_monthly,
+            currency=args.currency,
         )
 
     except KeyboardInterrupt:

--- a/find-phantom-resource.ps1
+++ b/find-phantom-resource.ps1
@@ -29,6 +29,15 @@
       - Phantom resources: visible via ARM REST but invisible to az resource list
       - Deleting RGs: resource groups stuck in the Deleting state
 
+    With -OrphanScan: uses Azure Resource Graph (KQL) for efficient
+    cross-subscription detection of orphaned resources:
+      - Unattached managed disks, old snapshots, unused images
+      - Orphaned NICs, public IPs, NSGs, route tables
+      - Empty availability sets, load balancers with no backends
+      - App Service Plans with no apps, orphaned NAT gateways
+      - Orphaned private DNS zones, private endpoints
+      - Azure Advisor cost recommendations
+
     This catches the same class of phantom resources as the single-RG mode but
     across the entire subscription. The -Region filter restricts which RGs are
     scanned (by RG location). Resources in the target region whose RG is located
@@ -104,6 +113,18 @@
     Scans all RGs in the subscription for phantom resources. Use when the
     target resource may be in a region that differs from its RG location.
 
+.EXAMPLE
+    pwsh find-phantom-resource.ps1 -OrphanScan
+
+    Uses Azure Resource Graph to find orphaned resources across the entire
+    subscription: unattached disks, orphaned NICs, empty availability sets,
+    App Service Plans with no apps, old snapshots, and more.
+
+.EXAMPLE
+    pwsh find-phantom-resource.ps1 -OrphanScan -SnapshotAgeDays 90
+
+    Same as -OrphanScan but only flags snapshots older than 90 days.
+
 .NOTES
     Requires: Azure CLI (az) authenticated and with an active subscription.
 #>
@@ -128,16 +149,32 @@ param(
     [switch]$Force,
 
     [Parameter(HelpMessage="Also delete the resource group after cleaning phantom resources")]
-    [switch]$DeleteResourceGroup
+    [switch]$DeleteResourceGroup,
+
+    [Parameter(HelpMessage="Use Azure Resource Graph for efficient orphaned resource detection across subscription")]
+    [switch]$OrphanScan,
+
+    [Parameter(HelpMessage="Age threshold in days for snapshot orphan detection (default: 30)")]
+    [int]$SnapshotAgeDays = 30
 )
 
+# Validate SnapshotAgeDays
+if ($SnapshotAgeDays -lt 1) {
+    Write-Host "ERROR: -SnapshotAgeDays must be at least 1." -ForegroundColor Red
+    exit 1
+}
+
 # Validate parameter combinations
+if ($OrphanScan -and ($SubScan -or $ResourceGroup)) {
+    Write-Host "ERROR: -OrphanScan cannot be combined with -SubScan or -ResourceGroup." -ForegroundColor Red
+    exit 1
+}
 if ($SubScan -and $ResourceGroup) {
     Write-Host "ERROR: -SubScan and -ResourceGroup are mutually exclusive." -ForegroundColor Red
     exit 1
 }
-if (-not $SubScan -and -not $ResourceGroup) {
-    Write-Host "ERROR: Provide -ResourceGroup <name> or -SubScan." -ForegroundColor Red
+if (-not $SubScan -and -not $ResourceGroup -and -not $OrphanScan) {
+    Write-Host "ERROR: Provide -ResourceGroup <name>, -SubScan, or -OrphanScan." -ForegroundColor Red
     exit 1
 }
 if ($SubScan -and ($Delete -or $DeleteResourceGroup)) {
@@ -172,18 +209,22 @@ $neverDeleteTypes = @(
     "Microsoft.Web/sites",
     "Microsoft.Web/serverFarms",
     "Microsoft.CognitiveServices/accounts",
-    "Microsoft.MachineLearningServices/workspaces"
+    "Microsoft.MachineLearningServices/workspaces",
+    "Microsoft.Compute/snapshots",
+    "Microsoft.Compute/images"
 )
 
 # Resource types that are safe to delete when orphaned
 $safeDeleteTypes = @(
     "Microsoft.Compute/disks",
+    "Microsoft.Compute/availabilitySets",
     "Microsoft.Network/networkInterfaces",
     "Microsoft.Network/publicIPAddresses",
     "Microsoft.Network/virtualNetworks",
     "Microsoft.Network/networkSecurityGroups",
     "Microsoft.Network/routeTables",
     "Microsoft.Network/loadBalancers",
+    "Microsoft.Network/natGateways",
     "Microsoft.Network/privateDnsZones",
     "Microsoft.Network/privateEndpoints"
 )
@@ -351,11 +392,220 @@ function Test-ResourceOrphaned {
             }
             return $false
         }
+        "Microsoft.Compute/snapshots" {
+            $snap = Invoke-AzRest -Url "${ResourceId}?api-version=2024-03-02"
+            if ($null -ne $snap) {
+                # Snapshot is orphaned if its source disk no longer exists
+                $sourceId = $snap.properties.creationData.sourceResourceId
+                if ([string]::IsNullOrWhiteSpace($sourceId)) {
+                    return $true
+                }
+                $sourceCheck = Invoke-AzRest -Url "${sourceId}?api-version=2024-03-02"
+                if ($null -eq $sourceCheck) {
+                    return $true  # Source disk no longer exists
+                }
+                # Also consider old snapshots (>$SnapshotAgeDays days) as candidates
+                $timeCreated = $snap.properties.timeCreated
+                if ($null -ne $timeCreated) {
+                    try {
+                        $created = [datetime]::Parse($timeCreated)
+                        if ($created -lt (Get-Date).AddDays(-$SnapshotAgeDays)) {
+                            return $true
+                        }
+                    } catch { }
+                }
+            }
+            return $false
+        }
+        "Microsoft.Compute/availabilitySets" {
+            $avset = Invoke-AzRest -Url "${ResourceId}?api-version=2024-07-01"
+            if ($null -ne $avset) {
+                $vms = $avset.properties.virtualMachines
+                if ($null -eq $vms -or $vms.Count -eq 0) {
+                    return $true
+                }
+            }
+            return $false
+        }
+        "Microsoft.Compute/images" {
+            # Custom VM images are orphaned if no VM references them
+            # Since there is no direct back-reference, mark as orphaned only
+            # if the source VM no longer exists
+            $img = Invoke-AzRest -Url "${ResourceId}?api-version=2024-07-01"
+            if ($null -ne $img) {
+                $sourceVm = $img.properties.sourceVirtualMachine
+                if ($null -ne $sourceVm -and -not [string]::IsNullOrWhiteSpace($sourceVm.id)) {
+                    $vmCheck = Invoke-AzRest -Url "$($sourceVm.id)?api-version=2024-07-01"
+                    if ($null -eq $vmCheck) {
+                        return $true  # Source VM no longer exists
+                    }
+                }
+            }
+            return $false
+        }
+        "Microsoft.Network/natGateways" {
+            $natgw = Invoke-AzRest -Url "${ResourceId}?api-version=2024-01-01"
+            if ($null -ne $natgw) {
+                $subnets = $natgw.properties.subnets
+                if ($null -eq $subnets -or $subnets.Count -eq 0) {
+                    return $true
+                }
+            }
+            return $false
+        }
         default {
             # Unknown type in safe-delete list: do NOT assume orphaned
             return $false
         }
     }
+}
+
+# ============================================================
+# ORPHANSCAN MODE: Azure Resource Graph orphaned resource scan
+# ============================================================
+if ($OrphanScan) {
+    Write-Host "Orphaned Resource Scan via Azure Resource Graph" -ForegroundColor Cyan
+    Write-Host "Requires: az extension 'resource-graph' (install with: az extension add --name resource-graph)`n"
+
+    # Verify resource-graph extension
+    $extCheck = az extension show --name resource-graph 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Installing resource-graph extension..." -ForegroundColor Yellow
+        az extension add --name resource-graph --only-show-errors
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "ERROR: Failed to install resource-graph extension." -ForegroundColor Red
+            exit 1
+        }
+    }
+
+    $queries = [ordered]@{
+        "Unattached Managed Disks" = @"
+Resources
+| where type =~ 'microsoft.compute/disks'
+| where isempty(managedBy)
+| extend diskState = tostring(properties.diskState)
+| where diskState == 'Unattached'
+| project name, resourceGroup, location, diskSizeGb=properties.diskSizeGB, sku=sku.name, subscriptionId
+"@
+        "Orphaned Network Interfaces" = @"
+Resources
+| where type =~ 'microsoft.network/networkinterfaces'
+| where isempty(properties.virtualMachine)
+| where isempty(properties.privateEndpoint)
+| project name, resourceGroup, location, subscriptionId
+"@
+        "Unassociated Public IPs" = @"
+Resources
+| where type =~ 'microsoft.network/publicipaddresses'
+| where isempty(properties.ipConfiguration)
+| where isempty(properties.natGateway)
+| project name, resourceGroup, location, sku=sku.name, ipAddress=properties.ipAddress, subscriptionId
+"@
+        "Unassociated NSGs" = @"
+Resources
+| where type =~ 'microsoft.network/networksecuritygroups'
+| where isnull(properties.networkInterfaces) or array_length(properties.networkInterfaces) == 0
+| where isnull(properties.subnets) or array_length(properties.subnets) == 0
+| project name, resourceGroup, location, subscriptionId
+"@
+        "Load Balancers with No Backend" = @"
+Resources
+| where type =~ 'microsoft.network/loadbalancers'
+| where array_length(properties.backendAddressPools) == 0
+| project name, resourceGroup, location, sku=sku.name, subscriptionId
+"@
+        "Empty Availability Sets" = @"
+Resources
+| where type =~ 'microsoft.compute/availabilitysets'
+| where array_length(properties.virtualMachines) == 0
+| project name, resourceGroup, location, subscriptionId
+"@
+        "App Service Plans with No Apps" = @"
+Resources
+| where type =~ 'microsoft.web/serverfarms'
+| where properties.numberOfSites == 0
+| project name, resourceGroup, location, sku=sku.name, tier=sku.tier, subscriptionId
+"@
+        "Unassociated Route Tables" = @"
+Resources
+| where type =~ 'microsoft.network/routetables'
+| where isnull(properties.subnets) or array_length(properties.subnets) == 0
+| project name, resourceGroup, location, subscriptionId
+"@
+        "Orphaned Snapshots (>$SnapshotAgeDays days)" = @"
+Resources
+| where type =~ 'microsoft.compute/snapshots'
+| extend timeCreated = todatetime(properties.timeCreated)
+| where timeCreated < ago(${SnapshotAgeDays}d)
+| project name, resourceGroup, location, diskSizeGb=properties.diskSizeGB, timeCreated, subscriptionId
+"@
+        "Orphaned NAT Gateways" = @"
+Resources
+| where type =~ 'microsoft.network/natgateways'
+| where isnull(properties.subnets) or array_length(properties.subnets) == 0
+| project name, resourceGroup, location, subscriptionId
+"@
+        "Orphaned Private DNS Zones" = @"
+Resources
+| where type =~ 'microsoft.network/privatednszones'
+| where properties.numberOfVirtualNetworkLinks == 0
+| project name, resourceGroup, location, subscriptionId
+"@
+        "Advisor Cost Recommendations" = @"
+AdvisorResources
+| where properties.category == 'Cost'
+| project name, impact=properties.impact, description=properties.shortDescription.solution, resourceId=properties.resourceMetadata.resourceId
+"@
+    }
+
+    $totalOrphans = 0
+    foreach ($queryName in $queries.Keys) {
+        Write-Host "`n=== $queryName ===" -ForegroundColor Cyan
+        $kql = $queries[$queryName]
+        try {
+            $allData = [System.Collections.Generic.List[object]]::new()
+            $skipToken = $null
+            $pageNum = 0
+            $maxPages = 10  # Safety limit
+
+            do {
+                $pageNum++
+                $graphArgs = @("graph", "query", "-q", $kql, "--first", "200", "-o", "json", "--only-show-errors")
+                if ($skipToken) {
+                    $graphArgs += @("--skip-token", $skipToken)
+                }
+                $resultJson = & az @graphArgs 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Host "  Query failed: $resultJson" -ForegroundColor Red
+                    break
+                }
+                $result = $resultJson | ConvertFrom-Json
+                if ($null -ne $result.data) {
+                    foreach ($item in $result.data) { $allData.Add($item) }
+                }
+                $skipToken = $result.'$skipToken'
+            } while ($skipToken -and $pageNum -lt $maxPages)
+
+            if ($allData.Count -gt 0) {
+                $totalOrphans += $allData.Count
+                Write-Host "  Found $($allData.Count) orphaned resource(s):" -ForegroundColor Yellow
+                $allData | Format-Table -AutoSize
+            } else {
+                Write-Host "  None found." -ForegroundColor Green
+            }
+        } catch {
+            Write-Host "  Error: $_" -ForegroundColor Red
+        }
+    }
+
+    Write-Host "`n=============================================" -ForegroundColor Cyan
+    if ($totalOrphans -gt 0) {
+        Write-Host "Total orphaned resources found: $totalOrphans" -ForegroundColor Yellow
+        Write-Host "Review each category above before deleting." -ForegroundColor Yellow
+    } else {
+        Write-Host "No orphaned resources found." -ForegroundColor Green
+    }
+    exit 0
 }
 
 # ============================================================
@@ -741,9 +991,13 @@ if ($DryRun -or $Delete) {
             # Delete in dependency order: NICs before VNets, disks anytime
             $deleteOrder = @(
                 "Microsoft.Compute/disks",
+                "Microsoft.Compute/snapshots",
+                "Microsoft.Compute/images",
+                "Microsoft.Compute/availabilitySets",
                 "Microsoft.Network/networkInterfaces",
                 "Microsoft.Network/publicIPAddresses",
                 "Microsoft.Network/loadBalancers",
+                "Microsoft.Network/natGateways",
                 "Microsoft.Network/privateEndpoints",
                 "Microsoft.Network/privateDnsZones",
                 "Microsoft.Network/networkSecurityGroups",

--- a/monitor-eviction.py
+++ b/monitor-eviction.py
@@ -29,6 +29,7 @@ from os import path, access, X_OK
 from platform import uname, node, system
 from subprocess import run
 from sys import stderr, exit
+from datetime import datetime, timezone
 from time import sleep
 from urllib.parse import urlparse
 
@@ -182,7 +183,12 @@ def is_valid_service_name(service_name):
 
 
 def parse_args():
-    parser = ArgumentParser(description="Monitor Azure spot VM eviction events.")
+    parser = ArgumentParser(
+        description="Monitor Azure Spot VM eviction events. "
+        "Spot VMs can be evicted with ~30 seconds notice when Azure needs capacity. "
+        "This script polls the Instance Metadata Service for scheduled events "
+        "and executes hooks/stops services before the VM is deallocated.",
+    )
     parser.add_argument(
         "--stop-services",
         type=str,
@@ -200,6 +206,18 @@ def parse_args():
         "--dry-run",
         action="store_true",
         help="Show what would be done without executing.",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=1,
+        help="Seconds between metadata service polls (default: 1, range: 1-30)",
+    )
+    parser.add_argument(
+        "--log-file",
+        type=str,
+        default=None,
+        help="Write eviction events to a log file in addition to stdout",
     )
     args = parser.parse_args()
 
@@ -224,11 +242,16 @@ def parse_args():
         except ValueError as e:
             parser.error(f"Hook validation failed: {e}")
 
-    return ret_services, ret_hook, ret_skip_azure_check, ret_dry_run
+    ret_poll_interval = args.poll_interval
+    if ret_poll_interval < 1 or ret_poll_interval > 30:
+        parser.error("--poll-interval must be between 1 and 30")
+    ret_log_file = args.log_file
+
+    return ret_services, ret_hook, ret_skip_azure_check, ret_dry_run, ret_poll_interval, ret_log_file
 
 
 if __name__ == "__main__":
-    services, hook, skip_azure_check, dry_run = parse_args()
+    services, hook, skip_azure_check, dry_run, poll_interval, log_file = parse_args()
 
     if not skip_azure_check:
         if system().lower() == "windows":
@@ -269,6 +292,7 @@ if __name__ == "__main__":
     if dry_run:
         print("DRY RUN MODE - No actual actions will be performed")
         print(f"Would monitor computer: {myComputer}")
+        print(f"Poll interval: {poll_interval}s")
         if services:
             print(f"Would stop services: {', '.join(services)}")
         if hook:
@@ -276,10 +300,19 @@ if __name__ == "__main__":
         exit(0)
 
     print(f"Monitoring eviction events for computer: {myComputer}")
+    print(f"Poll interval: {poll_interval}s")
     if services:
         print(f"Will stop services: {', '.join(services)}")
     if hook:
         print(f"Will execute hook: {hook}")
+
+    log_fh = None
+    if log_file:
+        try:
+            log_fh = open(log_file, "a", encoding="utf-8")
+            print(f"Logging to: {log_file}")
+        except IOError as e:
+            print(f"Warning: Cannot open log file {log_file}: {e}", file=stderr)
 
     continueLoop = True
     error_count = 0
@@ -315,11 +348,24 @@ if __name__ == "__main__":
                     and myComputer in resources
                 ):
                     print(f"Handling eviction signal: {eventType}")
+                    if log_fh:
+                        try:
+                            ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                            log_fh.write(f"{ts} EVICTION {eventType} {eventStatus} {myComputer}\n")
+                            log_fh.flush()
+                        except Exception as log_err:
+                            print(f"Warning: Failed to write to log file: {log_err}", file=stderr)
                     eviction_action(services, hook)
                     continueLoop = False
                     break
 
         if continueLoop:
-            sleep(1)
+            sleep(poll_interval)
+
+    if log_fh:
+        try:
+            log_fh.close()
+        except Exception:
+            pass
 
     print("Eviction monitoring completed")

--- a/vm-spot-price.py
+++ b/vm-spot-price.py
@@ -139,6 +139,30 @@ def create_resilient_session():
     return session
 
 
+def apply_common_filters(query: str, args: Any) -> str:
+    """Apply dedup-meters and region filters common to all query modes."""
+    if args.region:
+        regions = [r.strip() for r in args.region.split(",") if r.strip()]
+        if len(regions) == 1:
+            query += f" and armRegionName eq '{regions[0]}'"
+        elif len(regions) > 1:
+            region_filter = " or ".join(
+                [f"armRegionName eq '{r}'" for r in regions]
+            )
+            query += f" and ({region_filter})"
+    if args.dedup_meters:
+        query += " and isPrimaryMeterRegion eq true"
+    return query
+
+
+def build_api_params(query: str, args: Any) -> Dict[str, str]:
+    """Build API params dict with filter and optional currency."""
+    params: Dict[str, str] = {"$filter": query}
+    if args.currency:
+        params["currencyCode"] = args.currency
+    return params
+
+
 @rate_limit(calls_per_second=2)
 def fetch_pricing_data(
     api_url: str, params: Dict[str, str], session: Session, verbose: bool = False
@@ -1234,8 +1258,33 @@ def main() -> None:
         "Windows VMs typically cost 8-15%% more due to OS license fees. "
         "Uses 'productName contains Windows' filter for accurate results.",
     )
+    parser.add_argument(
+        "--estimate-monthly",
+        action="store_true",
+        help="Show estimated monthly cost (retail price * 730 hours/month)",
+    )
+    parser.add_argument(
+        "--currency",
+        type=str,
+        default=None,
+        help="Currency code for pricing (e.g., EUR, GBP, JPY). Default: USD",
+    )
+    parser.add_argument(
+        "--dedup-meters",
+        action="store_true",
+        help="Filter to isPrimaryMeterRegion=true to avoid duplicate regional meters",
+    )
 
     args: Namespace = parser.parse_args()
+
+    # Validate currency code
+    if args.currency:
+        if not re.match(r"^[A-Z]{3}$", args.currency):
+            logging.error("Currency must be a 3-letter ISO 4217 code (e.g., EUR, GBP, JPY)")
+            sys.exit(1)
+
+    # Derive currency label for output headers
+    currency_symbol = args.currency if args.currency else "USD"
 
     # Validate CPU vendor flags
     only_flags = [
@@ -1497,16 +1546,7 @@ def main() -> None:
                 )
                 if not non_spot:
                     query += SPOT_FILTER_CLAUSE
-                # Add region filter if specified
-                if args.region:
-                    regions = [r.strip() for r in args.region.split(",") if r.strip()]
-                    if len(regions) == 1:
-                        query += f" and armRegionName eq '{regions[0]}'"
-                    elif len(regions) > 1:
-                        region_filter = " or ".join(
-                            [f"armRegionName eq '{r}'" for r in regions]
-                        )
-                        query += f" and ({region_filter})"
+                query = apply_common_filters(query, args)
 
                 logging.debug(f"Query: {query}")
 
@@ -1517,8 +1557,9 @@ def main() -> None:
                     sys.exit(0)
 
                 page_start = time.time()
+                params = build_api_params(query, args)
                 json_data = fetch_pricing_data(
-                    api_url, {"$filter": query}, session, verbose=args.verbose
+                    api_url, params, session, verbose=args.verbose
                 )
                 PAGE_ESTIMATOR.record_page(time.time() - page_start)
                 items = json_data.get("Items", [])
@@ -1586,15 +1627,7 @@ def main() -> None:
                         query += f" and productName eq 'Virtual Machines {series_name} Series'"
                         if not non_spot:
                             query += SPOT_FILTER_CLAUSE
-                        if args.region:
-                            regions = [r.strip() for r in args.region.split(",") if r.strip()]
-                            if len(regions) == 1:
-                                query += f" and armRegionName eq '{regions[0]}'"
-                            elif len(regions) > 1:
-                                region_filter = " or ".join(
-                                    [f"armRegionName eq '{r}'" for r in regions]
-                                )
-                                query += f" and ({region_filter})"
+                        query = apply_common_filters(query, args)
                         print(f"\n  [{series_name}] Filter: {query}")
                     sys.exit(0)
 
@@ -1614,25 +1647,15 @@ def main() -> None:
                     query += f" and productName eq 'Virtual Machines {series_name} Series'"
                     if not non_spot:
                         query += SPOT_FILTER_CLAUSE
-                    # Add region filter if specified
-                    if args.region:
-                        regions = [
-                            r.strip() for r in args.region.split(",") if r.strip()
-                        ]
-                        if len(regions) == 1:
-                            query += f" and armRegionName eq '{regions[0]}'"
-                        elif len(regions) > 1:
-                            region_filter = " or ".join(
-                                [f"armRegionName eq '{r}'" for r in regions]
-                            )
-                            query += f" and ({region_filter})"
+                    query = apply_common_filters(query, args)
 
                     logging.debug(f"[{idx + 1}/{len(series_list)}] {series_name}: {query}")
 
                     try:
                         page_start = time.time()
+                        params = build_api_params(query, args)
                         json_data = fetch_pricing_data(
-                            api_url, {"$filter": query}, session, verbose=args.verbose
+                            api_url, params, session, verbose=args.verbose
                         )
                         PAGE_ESTIMATOR.record_page(time.time() - page_start)
                     except Exception as e:
@@ -1717,6 +1740,8 @@ def main() -> None:
                     "price": best_price,
                     "unit": best_unit,
                 }
+                if args.estimate_monthly:
+                    result["monthlyEstimate"] = round(best_price * 730, 2)
                 print(json.dumps(result))
             else:
                 print(f"{best_region} {best_vm_size} {best_price} {best_unit}")
@@ -1727,7 +1752,9 @@ def main() -> None:
             top_label = f"Top {args.top}" if args.top > 0 else "All"
             print(f"{top_label} cheapest per-core options:\n")
 
-            headers = ["SKU", "$/Hour", "$/Core/Hr", "Cores", "Region"]
+            headers = ["SKU", f"{currency_symbol}/Hour", f"{currency_symbol}/Core/Hr", "Cores", "Region"]
+            if args.estimate_monthly:
+                headers.insert(2, f"{currency_symbol}/Month")
             display_data = []
             seen = set()  # Deduplicate by SKU+region
             for row in per_core_data:
@@ -1735,15 +1762,16 @@ def main() -> None:
                 if key in seen:
                     continue
                 seen.add(key)
-                display_data.append(
-                    [
-                        row[0],  # SKU
-                        f"{row[1]:.6f}",  # Price (6 decimals for very low prices)
-                        f"{row[2]:.7f}",  # Price per core (7 decimals)
-                        row[3],  # Cores
-                        row[5],  # Region
-                    ]
-                )
+                entry = [
+                    row[0],  # SKU
+                    f"{row[1]:.6f}",  # Price (6 decimals for very low prices)
+                    f"{row[2]:.7f}",  # Price per core (7 decimals)
+                    row[3],  # Cores
+                    row[5],  # Region
+                ]
+                if args.estimate_monthly:
+                    entry.insert(2, f"{row[1] * 730:.2f}")
+                display_data.append(entry)
                 if args.top > 0 and len(display_data) >= args.top:
                     break
 
@@ -1782,16 +1810,7 @@ def main() -> None:
             query = "priceType eq 'Consumption' and serviceName eq 'Virtual Machines' and serviceFamily eq 'Compute'"
             if not non_spot:
                 query += SPOT_FILTER_CLAUSE
-            # Add region filter if specified
-            if args.region:
-                regions = [r.strip() for r in args.region.split(",") if r.strip()]
-                if len(regions) == 1:
-                    query += f" and armRegionName eq '{regions[0]}'"
-                elif len(regions) > 1:
-                    region_filter = " or ".join(
-                        [f"armRegionName eq '{r}'" for r in regions]
-                    )
-                    query += f" and ({region_filter})"
+            query = apply_common_filters(query, args)
 
             logging.debug(f"Query: {query}")
 
@@ -1802,8 +1821,9 @@ def main() -> None:
                 sys.exit(0)
 
             page_start = time.time()
+            params = build_api_params(query, args)
             json_data = fetch_pricing_data(
-                api_url, {"$filter": query}, session, verbose=args.verbose
+                api_url, params, session, verbose=args.verbose
             )
             PAGE_ESTIMATOR.record_page(time.time() - page_start)
             items = json_data.get("Items", [])
@@ -1929,6 +1949,8 @@ def main() -> None:
                     "price": best_price,
                     "unit": best_unit,
                 }
+                if args.estimate_monthly:
+                    result["monthlyEstimate"] = round(best_price * 730, 2)
                 print(json.dumps(result))
             else:
                 print(f"{best_region} {best_vm_size} {best_price} {best_unit}")
@@ -1947,9 +1969,16 @@ def main() -> None:
                 "Meter",
                 "Product Name",
             ]
+            if args.estimate_monthly:
+                headers.insert(2, f"{currency_symbol}/Month")
             display_data = all_series_data
             if args.top > 0:
                 display_data = all_series_data[: args.top]
+            if args.estimate_monthly:
+                display_data = [
+                    row[:2] + [f"{float(row[1]) * 730:.2f}"] + row[2:]
+                    for row in display_data
+                ]
             print(tabulate(display_data, headers=headers, tablefmt="psql"))
         sys.exit(0)
 
@@ -2060,17 +2089,6 @@ def main() -> None:
             if not non_spot:
                 query += SPOT_FILTER_CLAUSE
 
-            # Add region filter if specified
-            if args.region:
-                regions = [r.strip() for r in args.region.split(",") if r.strip()]
-                if len(regions) == 1:
-                    query += f" and armRegionName eq '{regions[0]}'"
-                elif len(regions) > 1:
-                    region_filter = " or ".join(
-                        [f"armRegionName eq '{r}'" for r in regions]
-                    )
-                    query += f" and ({region_filter})"
-
             # Skip productName filter when using --vm-sizes: armSkuName already
             # uniquely identifies the VM, and the series name casing may not match
             # Azure's productName (e.g. Fsv2 vs FSv2). Windows/Linux filtering
@@ -2095,12 +2113,15 @@ def main() -> None:
                             f"ARM VM detected ({sku}), skipping productName filter (client-side Windows filter)"
                         )
 
+            query = apply_common_filters(query, args)
+
             logging.debug(f"Query: {query}")
 
             # Initial request
             page_start = time.time()
+            params = build_api_params(query, args)
             json_data = fetch_pricing_data(
-                api_url, {"$filter": query}, session, verbose=args.verbose
+                api_url, params, session, verbose=args.verbose
             )
             PAGE_ESTIMATOR.record_page(time.time() - page_start)
             build_pricing_table(json_data, table_data, non_spot, low_priority)
@@ -2205,6 +2226,8 @@ def main() -> None:
                     "price": price,
                     "unit": unit,
                 }
+                if args.estimate_monthly:
+                    result["monthlyEstimate"] = round(price * 730, 2)
                 print(json.dumps(result))
             else:
                 # Output format: region vmsize price unit (space-separated)


### PR DESCRIPTION
## Summary
- **vm-spot-price.py**: Add --estimate-monthly (price*730), --currency (non-USD pricing), --dedup-meters (isPrimaryMeterRegion filter)
- **blob-storage-price.py**: Add --access-tier (hot/cool/cold/archive), --redundancy (LRS/ZRS/GRS), --estimate-monthly TB, --currency
- **monitor-eviction.py**: Update API version to 2024-03-01, add --poll-interval and --log-file, improve help text with Spot VM eviction context
- **find-phantom-resource.ps1**: Add -OrphanScan mode using Azure Resource Graph for cross-subscription orphan detection (12 resource types), add -SnapshotAgeDays, add detection for snapshots/availability sets/images/NAT gateways
- **README.md**: Clarify create-192core-vm.ps1 is a wrapper for vm-spot-price.py and create-spot-vms.ps1

## Test plan
- [ ] Run vm-spot-price.py with --estimate-monthly, --currency EUR, --dedup-meters
- [ ] Run blob-storage-price.py with --access-tier hot --redundancy LRS --estimate-monthly 1
- [ ] Run monitor-eviction.py --dry-run --poll-interval 5
- [ ] Run find-phantom-resource.ps1 -OrphanScan
- [ ] Run find-phantom-resource.ps1 -OrphanScan -SnapshotAgeDays 90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Subscription-wide orphan resource scan with snapshot-age filtering
  - Monthly cost estimation for VM and storage pricing queries (optional currency)
  - Storage access-tier and redundancy filtering
  - Adjustable eviction-monitor polling interval and optional log file
  - VM provisioning workflow now acts as an orchestrator and supports dry-run

* **Improvements**
  - Extended orphan detection to additional resource types and safer delete ordering
  - Added example usage and strengthened CLI validations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->