### PR TITLE
Fix Standard_ prefix doubling, bump Python to 3.12+, fix linter warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ A collection of Python and PowerShell utilities for Azure cost optimization, mon
 
 **Python Requirements:**
 
-- Python 3.6+
+- Python 3.12+
 - Required packages: `curl_cffi`, `tabulate`, `azure-storage-blob`, `azure-data-tables`, `Pillow`
 
 **PowerShell Requirements:**

--- a/blob-storage-price.py
+++ b/blob-storage-price.py
@@ -63,9 +63,7 @@ class AzurePricesFetcher:
 
         return session
 
-    def fetch_azure_prices(
-        self, params: Optional[Dict[str, str]]
-    ) -> List[Dict[str, Any]]:
+    def fetch_azure_prices(self, params: Optional[Dict[str, str]]) -> List[Dict[str, Any]]:
         """
         Fetch Azure retail prices from the API with proper error handling and security.
 
@@ -136,9 +134,7 @@ class AzurePricesFetcher:
 
                 # Validate response structure
                 if not isinstance(data, dict):
-                    print(
-                        "Invalid response format: expected JSON object", file=sys.stderr
-                    )
+                    print("Invalid response format: expected JSON object", file=sys.stderr)
                     sys.exit(1)
 
                 current_items = data.get("Items", [])
@@ -215,9 +211,7 @@ def validate_blob_types(blob_types_str: str) -> List[str]:
     validated_types = []
 
     # Define allowed characters for blob type names (security measure)
-    allowed_chars = set(
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 _-."
-    )
+    allowed_chars = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 _-.")
 
     for blob_type in blob_types:
         if not blob_type:
@@ -230,9 +224,7 @@ def validate_blob_types(blob_types_str: str) -> List[str]:
 
         # Validate characters
         if not set(blob_type).issubset(allowed_chars):
-            print(
-                f"Error: Invalid characters in blob type: {blob_type}", file=sys.stderr
-            )
+            print(f"Error: Invalid characters in blob type: {blob_type}", file=sys.stderr)
             sys.exit(1)
 
         validated_types.append(blob_type)
@@ -351,10 +343,10 @@ Security Notes:
     try:
         # Escape single quotes in blob type names for the filter
         escaped_types = [blob_type.replace("'", "''") for blob_type in blob_types]
-        product_filter = " or ".join(
-            f"productName eq '{blob_type}'" for blob_type in escaped_types
+        product_filter = " or ".join(f"productName eq '{blob_type}'" for blob_type in escaped_types)
+        api_filter = (
+            f"({product_filter}) and priceType eq 'Consumption' and serviceName eq 'Storage'"
         )
-        api_filter = f"({product_filter}) and priceType eq 'Consumption' and serviceName eq 'Storage'"
         if args.access_tier:
             tier_map = {
                 "hot": "Hot",
@@ -368,7 +360,10 @@ Security Notes:
         params = {"$filter": api_filter}
         if args.currency:
             if not args.currency.isalpha() or len(args.currency) != 3:
-                print("Error: Currency must be a 3-letter ISO 4217 code (e.g., EUR, GBP)", file=sys.stderr)
+                print(
+                    "Error: Currency must be a 3-letter ISO 4217 code (e.g., EUR, GBP)",
+                    file=sys.stderr,
+                )
                 sys.exit(1)
             params["currencyCode"] = args.currency
     except Exception as e:
@@ -422,9 +417,7 @@ def process_items(items: List[Dict[str, Any]], verbose: bool = False) -> Tuple[
                     continue
             except (ValueError, TypeError):
                 if verbose:
-                    print(
-                        f"Warning: Invalid price in item {i}, skipping", file=sys.stderr
-                    )
+                    print(f"Warning: Invalid price in item {i}, skipping", file=sys.stderr)
                 invalid_items += 1
                 continue
 
@@ -481,9 +474,7 @@ def calculate_region_prices(
     return region_prices
 
 
-def calculate_average_prices(
-    region_prices: Dict[str, List[float]]
-) -> List[Tuple[str, float]]:
+def calculate_average_prices(region_prices: Dict[str, List[float]]) -> List[Tuple[str, float]]:
     """Calculate average prices for each region."""
     region_avg_prices = []
 
@@ -519,8 +510,7 @@ def format_output(
             ]
         else:
             region_data = [
-                {"region": region, "avg_price": price}
-                for region, price in region_avg_prices
+                {"region": region, "avg_price": price} for region, price in region_avg_prices
             ]
         result = {
             "blob_types": blob_types,
@@ -555,17 +545,20 @@ def format_output(
             else f"Blob storage service ({blob_types[0]}) price per region"
         )
         print("\n" + table_caption)
+        formatted_data: list[tuple[str, ...]]
         if estimate_tb is not None:
-            headers = ["Region", f"Avg Price/GB ({currency_label})", f"Est. {currency_label}/Month ({estimate_tb} TB)"]
+            headers = [
+                "Region",
+                f"Avg Price/GB ({currency_label})",
+                f"Est. {currency_label}/Month ({estimate_tb} TB)",
+            ]
             formatted_data = [
                 (region, f"{price:.6f}", f"{price * estimate_tb * 1024:.2f}")
                 for region, price in region_avg_prices
             ]
         else:
             headers = ["Region", f"Average Price ({currency_label})"]
-            formatted_data = [
-                (region, f"{price:.6f}") for region, price in region_avg_prices
-            ]
+            formatted_data = [(region, f"{price:.6f}") for region, price in region_avg_prices]
         print(tabulate(formatted_data, headers=headers, tablefmt="psql"))
 
 
@@ -603,9 +596,7 @@ def main() -> None:
             print(f"Total services found: {len(service_regions)}", file=sys.stderr)
 
         # Calculate prices
-        region_prices = calculate_region_prices(
-            service_regions, service_prices, all_regions
-        )
+        region_prices = calculate_region_prices(service_regions, service_prices, all_regions)
         region_avg_prices = calculate_average_prices(region_prices)
 
         if not region_avg_prices:
@@ -614,7 +605,10 @@ def main() -> None:
 
         # Output results
         format_output(
-            blob_types, region_avg_prices, excluded_regions, args.output_format,
+            blob_types,
+            region_avg_prices,
+            excluded_regions,
+            args.output_format,
             estimate_tb=args.estimate_monthly,
             currency=args.currency,
         )

--- a/monitor-eviction.py
+++ b/monitor-eviction.py
@@ -15,15 +15,15 @@
 
 # Usage:
 # 1. Make the script executable: chmod +x monitor-eviction.py
-# 2. Run the script: ./monitor-eviction.py --stop-services <service1,service2> --hook <path_to_hook> [--skip-azure-check]
+# 2. Run the script:
+#    ./monitor-eviction.py --stop-services <service1,service2>
+#        --hook <path_to_hook> [--skip-azure-check]
 # 3. The script will run indefinitely, checking for eviction events every second.
 
 # The hook is executed before stopping the services.
 
 import os
 import re
-import shlex
-import sys
 from argparse import ArgumentParser
 from os import path, access, X_OK
 from platform import uname, node, system
@@ -31,7 +31,6 @@ from subprocess import run
 from sys import stderr, exit
 from datetime import datetime, timezone
 from time import sleep
-from urllib.parse import urlparse
 
 from requests import get, exceptions
 
@@ -63,9 +62,7 @@ def get_scheduled_events(max_retries=3, backoff_factor=2):
                 )
                 return {}
             wait_time = backoff_factor**attempt
-            print(
-                f"Metadata service error (attempt {attempt + 1}), retrying in {wait_time}s: {e}"
-            )
+            print(f"Metadata service error (attempt {attempt + 1}), retrying in {wait_time}s: {e}")
             sleep(wait_time)
     return {}
 
@@ -105,9 +102,7 @@ def validate_hook_path(hook_path):
     else:
         allowed_dirs = ["/opt/", "/usr/local/bin/", "/home/"]
     if not any(real_path.startswith(safe_dir) for safe_dir in allowed_dirs):
-        raise ValueError(
-            f"Hook script must be in allowed directories {allowed_dirs}: {real_path}"
-        )
+        raise ValueError(f"Hook script must be in allowed directories {allowed_dirs}: {real_path}")
 
     return real_path
 
@@ -139,24 +134,18 @@ def eviction_action(a_services, a_hook):
         try:
             if is_windows:
                 # Try "net stop" first, then "sc stop" as fallback
-                rc = run(
-                    ["net", "stop", service], check=False, timeout=60
-                ).returncode
+                rc = run(["net", "stop", service], check=False, timeout=60).returncode
                 if rc == 0:
                     print("Stopped service", service, "with net stop")
                 else:
-                    rc = run(
-                        ["sc", "stop", service], check=False, timeout=60
-                    ).returncode
+                    rc = run(["sc", "stop", service], check=False, timeout=60).returncode
                     if rc == 0:
                         print("Stopped service", service, "with sc stop")
                     else:
                         print("Error stopping service", service, "Return code", rc)
             else:
                 # Try systemctl first (modern systems)
-                rc = run(
-                    ["systemctl", "stop", service], check=False, timeout=60
-                ).returncode
+                rc = run(["systemctl", "stop", service], check=False, timeout=60).returncode
                 if rc == 0:
                     print("Stopped service", service, "with systemctl")
                 else:
@@ -247,7 +236,14 @@ def parse_args():
         parser.error("--poll-interval must be between 1 and 30")
     ret_log_file = args.log_file
 
-    return ret_services, ret_hook, ret_skip_azure_check, ret_dry_run, ret_poll_interval, ret_log_file
+    return (
+        ret_services,
+        ret_hook,
+        ret_skip_azure_check,
+        ret_dry_run,
+        ret_poll_interval,
+        ret_log_file,
+    )
 
 
 if __name__ == "__main__":
@@ -324,9 +320,7 @@ if __name__ == "__main__":
         if not payload:
             error_count += 1
             if error_count >= max_errors:
-                print(
-                    f"Too many consecutive errors ({error_count}), exiting", file=stderr
-                )
+                print(f"Too many consecutive errors ({error_count}), exiting", file=stderr)
                 exit(1)
             sleep(5)  # Wait longer on errors
             continue

--- a/monitor-stddev.md
+++ b/monitor-stddev.md
@@ -15,13 +15,13 @@ The program periodically checks the specified website, calculates relevant stati
 - Customizable user agent for website requests.
 
 ## Requirements
-- Python 3.x
+- Python 3.12+
 - `curl_cffi` package (impersonates Chrome TLS fingerprint to avoid Cloudflare bot detection)
 - `azure-storage-blob` package
 - `azure-data-tables` package
 - `Pillow` package (PIL)
-- `statistics` package (standard since Python 3.4)
-- `argparse` package (standard since Python 3.2)
+- `statistics` package (standard library)
+- `argparse` package (standard library)
 
 You can install the requirements using `python -m pip install curl_cffi azure-storage-blob azure-data-tables Pillow`
 

--- a/monitor-stddev.py
+++ b/monitor-stddev.py
@@ -9,7 +9,7 @@ Copyright (C) 2025-2026 Maxim Masiutin. All rights reserved.
 
 See monitor-stddev.md for details.
 
-You can install the requirements using `python -m pip install curl_cffi azure-storage-blob azure-data-tables Pillow`
+Install requirements: python -m pip install curl_cffi azure-storage-blob azure-data-tables Pillow
 """
 
 from time import time, sleep
@@ -55,10 +55,6 @@ def validate_file_path(file_path: str, operation: str = "access") -> str:
     # Resolve to absolute path
     real_path = path.realpath(file_path)
 
-    # After resolving, verify no traversal occurred by checking original didn't escape
-    # Get the absolute path of the original (without following symlinks initially)
-    abs_original = path.abspath(file_path)
-
     # Verify the resolved path is within the current working directory or an absolute path
     # that was explicitly provided (starts with / or drive letter on Windows)
     cwd = path.realpath(".")
@@ -95,9 +91,7 @@ SAMPLE_SIZE_SECONDS: int = 240
 UPDATE_INTERVAL_SECONDS: int = 60
 STATUS_UNHEALTHY: int = 0
 STATUS_HEALTHY: int = 1
-MAX_HISTORY_SIZE: int = (
-    SAMPLE_SIZE_SECONDS * 3
-)  # Keep some buffer to prevent memory leaks
+MAX_HISTORY_SIZE: int = SAMPLE_SIZE_SECONDS * 3  # Keep some buffer to prevent memory leaks
 
 
 def cleanup_old_data(data_list: List[Any], max_size: int) -> None:
@@ -150,9 +144,7 @@ def export_data(
 
                 # Use QUOTE_ALL to prevent CSV formula injection
                 with open(validated_path, "w", encoding="utf-8", newline="") as f:
-                    dict_writer = csv.DictWriter(
-                        f, fieldnames=fieldnames, quoting=csv.QUOTE_ALL
-                    )
+                    dict_writer = csv.DictWriter(f, fieldnames=fieldnames, quoting=csv.QUOTE_ALL)
                     dict_writer.writeheader()
                     dict_writer.writerows(data)
 
@@ -169,15 +161,11 @@ class DataStorage(ABC):
         self.historical_data: List[Dict[str, Union[str, int]]] = []
 
     @abstractmethod
-    def load_historical_data(
-        self, debug_output: bool
-    ) -> List[Dict[str, Union[str, int]]]:
+    def load_historical_data(self, debug_output: bool) -> List[Dict[str, Union[str, int]]]:
         pass
 
     @abstractmethod
-    def append_metric(
-        self, record: Dict[str, Union[str, int]], debug_output: bool
-    ) -> None:
+    def append_metric(self, record: Dict[str, Union[str, int]], debug_output: bool) -> None:
         pass
 
     @abstractmethod
@@ -196,9 +184,7 @@ class JsonFileStorage(DataStorage):
             raise
         self.historical_data = self.load_historical_data(debug_output=debug_output)
 
-    def load_historical_data(
-        self, debug_output: bool
-    ) -> List[Dict[str, Union[str, int]]]:
+    def load_historical_data(self, debug_output: bool) -> List[Dict[str, Union[str, int]]]:
         # self.filename is already validated in __init__
         # Use basename to sanitize and break taint chain
         safe_dir = path.dirname(path.realpath(self.filename))
@@ -218,24 +204,15 @@ class JsonFileStorage(DataStorage):
             except JSONDecodeError as json_err:
                 print(f"JSON decode error in {self.filename}: {json_err}", file=stderr)
             except (OSError, IOError) as file_err:
-                print(
-                    f"File error while reading {self.filename}: {file_err}", file=stderr
-                )
+                print(f"File error while reading {self.filename}: {file_err}", file=stderr)
             except Exception as e:
-                print(
-                    f"Unexpected error while loading historical data: {e}", file=stderr
-                )
+                print(f"Unexpected error while loading historical data: {e}", file=stderr)
             return []
-        else:
-            if debug_output:
-                print(
-                    f"No existing historical data file found at {self.filename}. Starting fresh."
-                )
-            return []
+        if debug_output:
+            print(f"No existing historical data file found at {self.filename}. Starting fresh.")
+        return []
 
-    def append_metric(
-        self, record: Dict[str, Union[str, int]], debug_output: bool
-    ) -> None:
+    def append_metric(self, record: Dict[str, Union[str, int]], debug_output: bool) -> None:
         self.historical_data.append(record)
         try:
             with open(self.filename, "w", encoding="utf-8") as file:
@@ -243,24 +220,18 @@ class JsonFileStorage(DataStorage):
             if debug_output:
                 print(f"Successfully appended metric to {self.filename}")
         except (OSError, IOError) as file_err:
-            print(
-                f"File error while writing to {self.filename}: {file_err}", file=stderr
-            )
+            print(f"File error while writing to {self.filename}: {file_err}", file=stderr)
         except TypeError as type_err:
             print(f"Type error during JSON serialization: {type_err}", file=stderr)
         except Exception as e:
             print(f"Unexpected error while appending metric: {e}", file=stderr)
 
     def print_raw_entities(self) -> None:
-        raise NotImplementedError(
-            "This method is not applicable for JSON file storage."
-        )
+        raise NotImplementedError("This method is not applicable for JSON file storage.")
 
 
 class CosmosDBTableStorage(DataStorage):
-    def __init__(
-        self, connection_string: str, table_name: str, debug_output: bool
-    ) -> None:
+    def __init__(self, connection_string: str, table_name: str, debug_output: bool) -> None:
         super().__init__()
         try:
             self.table_client = TableClient.from_connection_string(
@@ -271,9 +242,7 @@ class CosmosDBTableStorage(DataStorage):
             print(f"Failed to initialize Cosmos DB connection: {e}", file=stderr)
             raise
 
-    def load_historical_data(
-        self, debug_output: bool
-    ) -> List[Dict[str, Union[str, int]]]:
+    def load_historical_data(self, debug_output: bool) -> List[Dict[str, Union[str, int]]]:
         try:
             entities = list(self.table_client.list_entities())
             metrics: List[Dict[str, Union[str, int]]] = [
@@ -289,9 +258,7 @@ class CosmosDBTableStorage(DataStorage):
             print(f"Error loading data from Cosmos DB: {e}", file=stderr)
             return []
 
-    def append_metric(
-        self, record: Dict[str, Union[str, int]], debug_output: bool
-    ) -> None:
+    def append_metric(self, record: Dict[str, Union[str, int]], debug_output: bool) -> None:
         entity = {
             "PartitionKey": str(record["healthy"]),
             "RowKey": str(record["timestamp"]),
@@ -337,9 +304,7 @@ class FileSaver(ResultsSaver):
         self.save_name_json = save_name_json
         self.save_name_html = save_name_html
         self.save_name_png = f"{path.splitext(save_name_html)[0]}.png"
-        self.save_name_last_error_json = (
-            f"{path.splitext(save_name_json)[0]}-last_error.json"
-        )
+        self.save_name_last_error_json = f"{path.splitext(save_name_json)[0]}-last_error.json"
 
     def save_json(self, content: str, debug_output: bool) -> None:
         try:
@@ -379,16 +344,14 @@ class AzureBlobSaver(ResultsSaver):
         save_name_html: str,
     ) -> None:
         try:
-            blob_service_client: BlobServiceClient = (
-                BlobServiceClient.from_connection_string(azure_connection_string)
+            blob_service_client: BlobServiceClient = BlobServiceClient.from_connection_string(
+                azure_connection_string
             )
             self.azure_container_name = azure_container_name
             self.save_name_json = save_name_json
             self.save_name_html = save_name_html
             self.save_name_png = f"{path.splitext(save_name_html)[0]}.png"
-            self.save_name_last_error_json = (
-                f"{path.splitext(save_name_json)[0]}-last_error.json"
-            )
+            self.save_name_last_error_json = f"{path.splitext(save_name_json)[0]}-last_error.json"
             self.blob_client_json: BlobClient = blob_service_client.get_blob_client(
                 container=azure_container_name, blob=self.save_name_json
             )
@@ -398,10 +361,8 @@ class AzureBlobSaver(ResultsSaver):
             self.blob_client_png: BlobClient = blob_service_client.get_blob_client(
                 container=azure_container_name, blob=self.save_name_png
             )
-            self.blob_client_last_error_json: BlobClient = (
-                blob_service_client.get_blob_client(
-                    container=azure_container_name, blob=self.save_name_last_error_json
-                )
+            self.blob_client_last_error_json: BlobClient = blob_service_client.get_blob_client(
+                container=azure_container_name, blob=self.save_name_last_error_json
             )
         except Exception as e:
             print(f"Failed to initialize Azure Blob Storage: {e}", file=stderr)
@@ -418,7 +379,8 @@ class AzureBlobSaver(ResultsSaver):
             )
             if debug_output:
                 print(
-                    f"JSON data uploaded to Azure: {self.azure_container_name}/{self.save_name_json}"
+                    f"JSON data uploaded to Azure: "
+                    f"{self.azure_container_name}/{self.save_name_json}"
                 )
         except Exception as e:
             print(f"Error uploading JSON to Azure: {e}", file=stderr)
@@ -434,7 +396,8 @@ class AzureBlobSaver(ResultsSaver):
             )
             if debug_output:
                 print(
-                    f"HTML data uploaded to Azure: {self.azure_container_name}/{self.save_name_html}"
+                    f"HTML data uploaded to Azure: "
+                    f"{self.azure_container_name}/{self.save_name_html}"
                 )
         except Exception as e:
             print(f"Error uploading HTML to Azure: {e}", file=stderr)
@@ -466,7 +429,8 @@ class AzureBlobSaver(ResultsSaver):
             )
             if debug_output:
                 print(
-                    f"Last error JSON uploaded: {self.azure_container_name}/{self.save_name_last_error_json}"
+                    f"Last error JSON uploaded: "
+                    f"{self.azure_container_name}/{self.save_name_last_error_json}"
                 )
         except Exception as e:
             print(f"Error uploading last error JSON to Azure: {e}", file=stderr)
@@ -481,11 +445,10 @@ def save_json(file_name: str, data: List[Dict[str, Union[str, int]]]) -> None:
         print(f"Error saving JSON file {file_name}: {e}", file=stderr)
 
 
-def trim_data(
-    data: List[Dict[str, Union[str, int]]]
-) -> List[Dict[str, Union[str, int]]]:
+def trim_data(data: List[Dict[str, Union[str, int]]]) -> List[Dict[str, Union[str, int]]]:
     """
-    Remove one-minute-duplicates (entries with time difference < 59.99s) and keep only the last DATASET_LENGTH_MINUTES items.
+    Remove one-minute-duplicates (entries with time difference < 59.99s)
+    and keep only the last DATASET_LENGTH_MINUTES items.
     """
     if not data:
         return []
@@ -570,8 +533,8 @@ def create_graphical_representation(
         # Add date markers
         if font_file_name and path.exists(font_file_name):
             try:
-                font: Union[ImageFont.FreeTypeFont, ImageFont.ImageFont] = (
-                    ImageFont.truetype(font_file_name, size=40)
+                font: Union[ImageFont.FreeTypeFont, ImageFont.ImageFont] = ImageFont.truetype(
+                    font_file_name, size=40
                 )
             except Exception:
                 font = ImageFont.load_default()
@@ -597,9 +560,7 @@ def create_graphical_representation(
                             anchor = "ra"
                         else:
                             anchor = "ma"
-                        draw.text(
-                            (x_pos, 10), date_str, font=font, fill=3, anchor=anchor
-                        )
+                        draw.text((x_pos, 10), date_str, font=font, fill=3, anchor=anchor)
                 previous_date = current_date
             except (ValueError, KeyError):
                 continue
@@ -645,7 +606,6 @@ def render_history_to_png_file(
         print(f"Error saving PNG file {validated_path}: {e}", file=stderr)
 
 
-
 def get_firefox_impersonate() -> str:
     """Get best available Firefox impersonation for curl_cffi.
 
@@ -653,8 +613,9 @@ def get_firefox_impersonate() -> str:
     """
     try:
         from curl_cffi.requests import BrowserType
+
         # Prefer newest Firefox version available
-        for browser in ['firefox144', 'firefox135', 'firefox133']:
+        for browser in ["firefox144", "firefox135", "firefox133"]:
             if hasattr(BrowserType, browser):
                 return browser
     except (ImportError, AttributeError):
@@ -719,14 +680,12 @@ def monitor_website(
             print("Falling back to local file storage.")
             saver = FileSaver(save_name_json, save_name_html)
     else:
-        print(
-            "Not using Azure storage since connection string/container name not supplied."
-        )
+        print("Not using Azure storage since connection string/container name not supplied.")
         saver = FileSaver(save_name_json, save_name_html)
 
     # Use browser impersonation for TLS fingerprint to avoid bot detection
     # If user-agent contains "Firefox", use Firefox impersonation; otherwise Chrome
-    browser_impersonate = "chrome"
+    browser_impersonate: Any = "chrome"
     if user_agent and "firefox" in user_agent.lower():
         browser_impersonate = get_firefox_impersonate()
     session = Session(impersonate=browser_impersonate) if use_session else None
@@ -777,9 +736,7 @@ def monitor_website(
                             f"{response_status_code}_{save_name_html.rsplit('.', 1)[0]}{err_ext}"
                         )
                         try:
-                            with open(
-                                error_file_name, "w", encoding="utf-8"
-                            ) as error_file:
+                            with open(error_file_name, "w", encoding="utf-8") as error_file:
                                 error_file.write(response.text)
                         except Exception as file_err:
                             print(
@@ -805,13 +762,9 @@ def monitor_website(
 
             # Propagate results for each second in the interval
             errors.extend([current_probe_error] * probe_interval)
-            effective_latencies.extend(
-                [current_probe_effective_latency] * probe_interval
-            )
+            effective_latencies.extend([current_probe_effective_latency] * probe_interval)
             adjusted_latencies.extend([current_probe_adjusted_latency] * probe_interval)
-            response_status_codes.extend(
-                [current_probe_response_status_code] * probe_interval
-            )
+            response_status_codes.extend([current_probe_response_status_code] * probe_interval)
 
             # Clean up old data to prevent memory leaks
             cleanup_old_data(errors, MAX_HISTORY_SIZE)
@@ -838,20 +791,14 @@ def monitor_website(
                 max_eff = max(valid_eff_latencies) if valid_eff_latencies else 0.0
                 avg_eff = mean(valid_eff_latencies) if valid_eff_latencies else 0.0
                 avg_adj = mean(valid_adj_latencies) if valid_adj_latencies else 0.0
-                std_dev_eff = (
-                    stdev(valid_eff_latencies) if len(valid_eff_latencies) > 1 else 0.0
-                )
-                std_dev_adj = (
-                    stdev(valid_adj_latencies) if len(valid_adj_latencies) > 1 else 0.0
-                )
+                std_dev_eff = stdev(valid_eff_latencies) if len(valid_eff_latencies) > 1 else 0.0
+                std_dev_adj = stdev(valid_adj_latencies) if len(valid_adj_latencies) > 1 else 0.0
 
                 num_errors = sum(1 for e in analysis_errors if e is True)
                 error_rate: float = (num_errors / SAMPLE_SIZE_SECONDS) * 100.0
 
                 # Find most common non-200 status code in the analysis window
-                error_codes = [
-                    cd for cd in analysis_status_codes if cd is not None and cd != 200
-                ]
+                error_codes = [cd for cd in analysis_status_codes if cd is not None and cd != 200]
                 most_common_code: Optional[int] = 200
                 if error_codes:
                     code_counts = Counter(error_codes)
@@ -871,7 +818,8 @@ def monitor_website(
                     print(
                         f"Probe @ {probe_timestamp_dt.strftime('%H:%M:%S')}: "
                         f"AvgEff: {avg_eff:.3f}s, AvgAdj: {avg_adj:.3f}s, Err%: {error_rate:.1f}, "
-                        f"StdEff: {std_dev_eff:.3f}s, StdAdj: {std_dev_adj:.3f}s, Code: {most_common_code}, Health: {health_status}"
+                        f"StdEff: {std_dev_eff:.3f}s, StdAdj: {std_dev_adj:.3f}s, "
+                        f"Code: {most_common_code}, Health: {health_status}"
                     )
 
                 timestamp_str = probe_timestamp_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -903,21 +851,21 @@ def monitor_website(
                 )
                 data_json_str: str = dumps(json_data, indent=4)
 
-                health_text: str = (
-                    "Healthy" if health_status == STATUS_HEALTHY else "Unhealthy"
-                )
-                health_color: str = (
-                    "green" if health_status == STATUS_HEALTHY else "red"
-                )
+                health_text: str = "Healthy" if health_status == STATUS_HEALTHY else "Unhealthy"
+                health_color: str = "green" if health_status == STATUS_HEALTHY else "red"
 
-                local_dt = probe_timestamp_dt.astimezone(
-                    timezone(timedelta(hours=tz_offset))
-                )
+                local_dt = probe_timestamp_dt.astimezone(timezone(timedelta(hours=tz_offset)))
                 local_dt_str: str = local_dt.strftime("%Y-%m-%d %H:%M:%S ") + tz_caption
 
                 escaped_title: str = html.escape(page_title) if page_title else ""
                 title_prefix: str = f"{escaped_title} - " if escaped_title else ""
-                title_heading: str = f'<h1 class="title">{escaped_title}</h1>' if escaped_title else ""
+                title_heading: str = (
+                    f'<h1 class="title">{escaped_title}</h1>' if escaped_title else ""
+                )
+
+                err_json = f"{path.splitext(save_name_json)[0]}-last_error.json"
+                img_src = f"{path.splitext(save_name_html)[0]}.png"
+                hours_count = RESULTS_COUNT_MINUTES // 60
 
                 data_html: str = f"""
                 <!DOCTYPE html>
@@ -971,9 +919,9 @@ def monitor_website(
                     <div class="status">{health_text}</div>
                     <div class="time">{local_dt_str}</div>
                     <div class="link"><a href="{save_name_json}">{save_name_json}</a></div>
-                    <div class="link"><a href="{path.splitext(save_name_json)[0]}-last_error.json">{path.splitext(save_name_json)[0]}-last_error.json</a></div>
+                    <div class="link"><a href="{err_json}">{err_json}</a></div>
                     <div class="image-container">
-                        <img src="{path.splitext(save_name_html)[0]}.png" alt="Health Status for Last {RESULTS_COUNT_MINUTES // (60)} Hours">
+                        <img src="{img_src}" alt="Health Status for Last {hours_count} Hours">
                     </div>
                 </body>
                 </html>
@@ -1045,7 +993,7 @@ def test_url(
     print("-" * 60)
 
     # Use browser impersonation matching user-agent
-    browser_impersonate = "chrome"
+    browser_impersonate: Any = "chrome"
     if user_agent and "firefox" in user_agent.lower():
         browser_impersonate = get_firefox_impersonate()
     headers = build_request_headers(user_agent, authorization)
@@ -1107,32 +1055,25 @@ def test_url(
             if is_cloudflare:
                 print("Note: Cloudflare detected but request succeeded")
             return 0
-        elif response.status_code == 403:
+        if response.status_code == 403:
             print("Result: BLOCKED - access forbidden")
             if is_cloudflare or cf_ray:
                 print("Reason: Cloudflare protection detected")
-                print(
-                    "Solution: Whitelist monitoring server IP in Cloudflare firewall rules"
-                )
+                print("Solution: Whitelist monitoring server IP in Cloudflare firewall rules")
             return 1
-        elif is_captcha:
+        if is_captcha:
             print("Result: BLOCKED - CAPTCHA challenge detected")
-            print(
-                "Reason: Cloudflare or similar protection requiring human verification"
-            )
-            print(
-                "Solution: Whitelist monitoring server IP in Cloudflare firewall rules"
-            )
+            print("Reason: Cloudflare or similar protection requiring human verification")
+            print("Solution: Whitelist monitoring server IP in Cloudflare firewall rules")
             if response.text:
                 preview = response.text[:500].replace("\n", " ").replace("\r", "")
                 print(f"Body preview: {preview}...")
             return 1
-        elif response.status_code >= 400:
+        if response.status_code >= 400:
             print(f"Result: ERROR - HTTP {response.status_code}")
             return 1
-        else:
-            print(f"Result: OK - status {response.status_code}")
-            return 0
+        print(f"Result: OK - status {response.status_code}")
+        return 0
 
     except Exception as e:
         print(f"Result: FAILED - {e}")
@@ -1147,15 +1088,9 @@ def main() -> None:
 
     parser = ArgumentParser(description="Website Health Monitoring Script")
     parser.add_argument("--url", type=str, help="The URL of the website to monitor")
-    parser.add_argument(
-        "--authorization", type=str, help='Specify "Authorization" header'
-    )
-    parser.add_argument(
-        "--user-agent", type=str, help='Overrides the "User-Agent" header'
-    )
-    parser.add_argument(
-        "--timeout", type=float, default=2.0, help="Request timeout in seconds"
-    )
+    parser.add_argument("--authorization", type=str, help='Specify "Authorization" header')
+    parser.add_argument("--user-agent", type=str, help='Overrides the "User-Agent" header')
+    parser.add_argument("--timeout", type=float, default=2.0, help="Request timeout in seconds")
     parser.add_argument(
         "--probe-interval",
         type=int,
@@ -1204,9 +1139,7 @@ def main() -> None:
         default="index.html",
         help="Blob/file name for HTML results",
     )
-    parser.add_argument(
-        "--tz-offset", type=float, default=0.0, help="Time zone offset in hours"
-    )
+    parser.add_argument("--tz-offset", type=float, default=0.0, help="Time zone offset in hours")
     parser.add_argument("--tz-caption", type=str, default="UTC", help="Time zone label")
     parser.add_argument(
         "--page-title",
@@ -1214,12 +1147,8 @@ def main() -> None:
         default=None,
         help="Optional title shown as a heading on the HTML status page",
     )
-    parser.add_argument(
-        "--render-history-input", type=str, help="Render history from a JSON file"
-    )
-    parser.add_argument(
-        "--render-history-output", type=str, help="Output PNG file for history"
-    )
+    parser.add_argument("--render-history-input", type=str, help="Render history from a JSON file")
+    parser.add_argument("--render-history-output", type=str, help="Output PNG file for history")
     parser.add_argument(
         "--cosmosdb-connection-string",
         type=str,
@@ -1322,9 +1251,7 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
-        export_data(
-            storage.historical_data, args.export_file, args.export_format, args.debug
-        )
+        export_data(storage.historical_data, args.export_file, args.export_format, args.debug)
         return
 
     storage.historical_data = trim_data(storage.historical_data)
@@ -1337,9 +1264,7 @@ def main() -> None:
         return
 
     if args.render_history_input and args.render_history_output:
-        print(
-            f"Rendering history from {args.render_history_input} to {args.render_history_output}"
-        )
+        print(f"Rendering history from {args.render_history_input} to {args.render_history_output}")
         try:
             render_history_to_png_file(
                 storage.historical_data,
@@ -1371,9 +1296,7 @@ def main() -> None:
             sys.exit(exit_code)
 
         if not 1 <= args.probe_interval <= 60:
-            print(
-                "Error: Probe interval must be between 1 and 60 seconds.", file=stderr
-            )
+            print("Error: Probe interval must be between 1 and 60 seconds.", file=stderr)
             sys.exit(1)
 
         print(f"Starting website monitoring for: {args.url}")

--- a/vm-spot-price.py
+++ b/vm-spot-price.py
@@ -131,9 +131,7 @@ def create_resilient_session():
         backoff_factor=1,
         status_forcelist=[429, 500, 502, 503, 504],
     )
-    adapter = HTTPAdapter(
-        max_retries=retry_strategy, pool_connections=10, pool_maxsize=10
-    )
+    adapter = HTTPAdapter(max_retries=retry_strategy, pool_connections=10, pool_maxsize=10)
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     return session
@@ -146,9 +144,7 @@ def apply_common_filters(query: str, args: Any) -> str:
         if len(regions) == 1:
             query += f" and armRegionName eq '{regions[0]}'"
         elif len(regions) > 1:
-            region_filter = " or ".join(
-                [f"armRegionName eq '{r}'" for r in regions]
-            )
+            region_filter = " or ".join([f"armRegionName eq '{r}'" for r in regions])
             query += f" and ({region_filter})"
     if args.dedup_meters:
         query += " and isPrimaryMeterRegion eq true"
@@ -399,9 +395,7 @@ class PageEstimator:
         minutes = int((eta_seconds % 3600) // 60)
         return f"{hours}h{minutes:02d}m"
 
-    def format_progress(
-        self, current_page: int, total_pages: int, prefix: str = "Fetching"
-    ) -> str:
+    def format_progress(self, current_page: int, total_pages: int, prefix: str = "Fetching") -> str:
         """Format progress string with page count and ETA."""
         eta = self.get_eta_str(current_page, total_pages)
         return f"{prefix} page {current_page}/{total_pages} (ETA: {eta})"
@@ -426,7 +420,7 @@ def extract_series_from_vm_size(vm_size: str) -> str:
         B4ls_v2 -> Blsv2
     """
     # Remove leading Standard_ if present
-    vm_size = vm_size.replace("Standard_", "")
+    vm_size = vm_size.removeprefix("Standard_")
     # Remove numeric part (the vCPU count)
     # Pattern: letter(s) + digits + rest
     match = re.match(r"^([A-Za-z]+)(\d+)(.*)$", vm_size)
@@ -449,7 +443,7 @@ def extract_cores_from_sku(sku_name: str) -> int:
         Standard_E96as_v5 -> 96
     """
     # Remove Standard_ prefix if present
-    sku_name = sku_name.replace("Standard_", "")
+    sku_name = sku_name.removeprefix("Standard_")
     # Pattern: letter(s) + digits (the core count)
     match = re.match(r"^[A-Za-z]+(\d+)", sku_name)
     if match:
@@ -465,7 +459,7 @@ def is_burstable_vm(sku_name: str) -> bool:
         Standard_D4pls_v5 -> False
     """
     # Remove Standard_ prefix if present
-    sku_name = sku_name.replace("Standard_", "")
+    sku_name = sku_name.removeprefix("Standard_")
     # B-series VMs start with 'B'
     return sku_name.upper().startswith("B")
 
@@ -484,7 +478,7 @@ def is_arm_vm(sku_name: str) -> bool:
         Dplsv6 -> True (series name)
     """
     # Remove Standard_ prefix if present
-    sku_name = sku_name.replace("Standard_", "")
+    sku_name = sku_name.removeprefix("Standard_")
     # ARM VMs have 'p' after the first letter(s) and before 's' or 'l'
     # Pattern: letter(s) + digits + 'p' + optional 'l/d' + 's'
     # Or for series names: letter(s) + 'p' + optional letters + 'v' + digit
@@ -514,7 +508,7 @@ def is_amd_vm(sku_name: str) -> bool:
         Dasv5 -> True (series name)
         Famsv6 -> True (series name, AMD high memory)
     """
-    sku_name = sku_name.replace("Standard_", "")
+    sku_name = sku_name.removeprefix("Standard_")
     amd_patterns = [
         r"^[A-Za-z]+\d+(?:-\d+)?a[ldms]*_v\d+",  # SKU: D4as_v5, E64-16as_v7
         r"^[A-Za-z]+\d+(?:-\d+)?a[ldms]*_[A-Za-z]",  # SKU with suffix: NV72ads_A10_v5
@@ -943,11 +937,7 @@ VM_SERIES_SPECIALTY = (
 )
 
 # Complete catalog: every known series
-VM_SERIES_ALL = (
-    VM_SERIES_BURSTABLE
-    + VM_SERIES_NON_BURSTABLE
-    + VM_SERIES_SPECIALTY
-)
+VM_SERIES_ALL = VM_SERIES_BURSTABLE + VM_SERIES_NON_BURSTABLE + VM_SERIES_SPECIALTY
 
 # Latest generation only (v6/v7) - for fast queries
 VM_SERIES_LATEST = (
@@ -1025,7 +1015,7 @@ def _process_per_core_item(
 
         # Filter for general-compute: only D and F series (non-burstable)
         if getattr(args, "general_compute", False):
-            sku_upper = arm_sku_name.replace("Standard_", "").upper()
+            sku_upper = arm_sku_name.removeprefix("Standard_").upper()
             # Only allow D-series and F-series (general purpose + compute optimized)
             if not (sku_upper.startswith("D") or sku_upper.startswith("F")):
                 return
@@ -1038,7 +1028,7 @@ def _process_per_core_item(
             return
 
         # Filter excluded VM sizes
-        normalized_sku = arm_sku_name.replace("Standard_", "").lower()
+        normalized_sku = arm_sku_name.removeprefix("Standard_").lower()
         if normalized_sku in excluded_vm_sizes:
             return
 
@@ -1068,9 +1058,7 @@ def _process_per_core_item(
 
 def main() -> None:
     """Main entry point for Azure VM spot price finder."""
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 
     table_data: List[List[Any]] = []
     parser: ArgumentParser = ArgumentParser(description="Get Azure VM spot prices")
@@ -1098,9 +1086,7 @@ def main() -> None:
         help="Comma-separated VM sizes (e.g., D4pls_v5,D4ps_v5). "
         "Overrides --sku-pattern and --series-pattern",
     )
-    parser.add_argument(
-        "--non-spot", action="store_true", help="Only return non-spot instances"
-    )
+    parser.add_argument("--non-spot", action="store_true", help="Only return non-spot instances")
     parser.add_argument(
         "--low-priority",
         action="store_true",
@@ -1150,9 +1136,7 @@ def main() -> None:
         help="Output format (default: %(default)s)",
     )
     parser.add_argument("--output-file", help="Save output to file instead of stdout")
-    parser.add_argument(
-        "--dry-run", action="store_true", help="Show API query without executing"
-    )
+    parser.add_argument("--dry-run", action="store_true", help="Show API query without executing")
     parser.add_argument(
         "--validate-config", action="store_true", help="Validate configuration and exit"
     )
@@ -1294,9 +1278,7 @@ def main() -> None:
     ]
     active_only = [name for name, val in only_flags if val]
     if len(active_only) > 1:
-        logging.error(
-            f"Cannot specify multiple --*-only flags: {', '.join(active_only)}"
-        )
+        logging.error(f"Cannot specify multiple --*-only flags: {', '.join(active_only)}")
         sys.exit(1)
     if getattr(args, "intel_only", False) and getattr(args, "exclude_intel", False):
         logging.error("Cannot specify both --intel-only and --exclude-intel")
@@ -1307,11 +1289,13 @@ def main() -> None:
     if getattr(args, "arm_only", False) and getattr(args, "exclude_arm", False):
         logging.error("Cannot specify both --arm-only and --exclude-arm")
         sys.exit(1)
-    exclude_count = sum([
-        getattr(args, "exclude_intel", False),
-        getattr(args, "exclude_amd", False),
-        getattr(args, "exclude_arm", False),
-    ])
+    exclude_count = sum(
+        [
+            getattr(args, "exclude_intel", False),
+            getattr(args, "exclude_amd", False),
+            getattr(args, "exclude_arm", False),
+        ]
+    )
     if exclude_count >= 3:
         logging.error("Cannot exclude all three CPU vendors (Intel, AMD, ARM)")
         sys.exit(1)
@@ -1394,9 +1378,7 @@ def main() -> None:
                             excluded_regions.add(rgn)
                 logging.debug(f"Loaded exclusions from {exclude_file}")
             except IOError as e:
-                logging.warning(
-                    f"Could not read exclude-regions-file {exclude_file}: {e}"
-                )
+                logging.warning(f"Could not read exclude-regions-file {exclude_file}: {e}")
     if excluded_regions:
         logging.debug(f"Excluding regions: {', '.join(sorted(excluded_regions))}")
 
@@ -1407,7 +1389,7 @@ def main() -> None:
             sz = sz.strip()
             if sz:
                 # Normalize: remove Standard_ prefix if present, store lowercase
-                sz = sz.replace("Standard_", "").lower()
+                sz = sz.removeprefix("Standard_").lower()
                 excluded_vm_sizes.add(sz)
     if args.exclude_vm_sizes_file:
         try:
@@ -1415,7 +1397,7 @@ def main() -> None:
                 for line in f:
                     sz = line.strip()
                     if sz and not sz.startswith("#"):
-                        sz = sz.replace("Standard_", "").lower()
+                        sz = sz.removeprefix("Standard_").lower()
                         excluded_vm_sizes.add(sz)
         except IOError as e:
             logging.warning(f"Could not read exclude-vm-sizes-file: {e}")
@@ -1510,17 +1492,13 @@ def main() -> None:
         # Pre-filter series list by vendor to avoid unnecessary API calls
         if series_list:
             original_count = len(series_list)
-            series_list = [
-                s for s in series_list if not should_skip_by_vendor(s, args)
-            ]
+            series_list = [s for s in series_list if not should_skip_by_vendor(s, args)]
             if len(series_list) < original_count:
                 logging.debug(
                     f"Vendor filter reduced series from {original_count} to {len(series_list)}"
                 )
             if not series_list:
-                logging.error(
-                    "No VM series remain after applying CPU vendor filters"
-                )
+                logging.error("No VM series remain after applying CPU vendor filters")
                 sys.exit(1)
 
         try:
@@ -1536,9 +1514,7 @@ def main() -> None:
                     print(
                         f"Searching for cheapest spot price per core ({args.min_cores}-{args.max_cores} vCPUs)..."
                     )
-                    print(
-                        f"Fetching all VM pricing data (~{estimated_pages} pages expected)..."
-                    )
+                    print(f"Fetching all VM pricing data (~{estimated_pages} pages expected)...")
 
                 query = (
                     "priceType eq 'Consumption' and serviceName eq 'Virtual Machines' "
@@ -1558,9 +1534,7 @@ def main() -> None:
 
                 page_start = time.time()
                 params = build_api_params(query, args)
-                json_data = fetch_pricing_data(
-                    api_url, params, session, verbose=args.verbose
-                )
+                json_data = fetch_pricing_data(api_url, params, session, verbose=args.verbose)
                 PAGE_ESTIMATOR.record_page(time.time() - page_start)
                 items = json_data.get("Items", [])
                 next_page = json_data.get("NextPageLink", "")
@@ -1574,9 +1548,7 @@ def main() -> None:
                         print(f"\r{progress_msg}        ", end="", flush=True)
                     try:
                         page_start = time.time()
-                        json_data = fetch_pricing_data(
-                            next_page, {}, session, verbose=args.verbose
-                        )
+                        json_data = fetch_pricing_data(next_page, {}, session, verbose=args.verbose)
                         PAGE_ESTIMATOR.record_page(time.time() - page_start)
                         items.extend(json_data.get("Items", []))
                         next_page = json_data.get("NextPageLink", "")
@@ -1721,9 +1693,7 @@ def main() -> None:
         per_core_data.sort(key=lambda x: x[2])
 
         unique_regions = set(row[5] for row in per_core_data)
-        logging.debug(
-            f"Total: {len(per_core_data)} entries across {len(unique_regions)} regions"
-        )
+        logging.debug(f"Total: {len(per_core_data)} entries across {len(unique_regions)} regions")
 
         # Output results
         if return_region:
@@ -1752,7 +1722,13 @@ def main() -> None:
             top_label = f"Top {args.top}" if args.top > 0 else "All"
             print(f"{top_label} cheapest per-core options:\n")
 
-            headers = ["SKU", f"{currency_symbol}/Hour", f"{currency_symbol}/Core/Hr", "Cores", "Region"]
+            headers = [
+                "SKU",
+                f"{currency_symbol}/Hour",
+                f"{currency_symbol}/Core/Hr",
+                "Cores",
+                "Region",
+            ]
             if args.estimate_monthly:
                 headers.insert(2, f"{currency_symbol}/Month")
             display_data = []
@@ -1795,16 +1771,12 @@ def main() -> None:
 
         # Estimate pages for all-vm-series mode
         has_region = bool(args.region)
-        estimated_pages = PAGE_ESTIMATOR.estimate_pages(
-            "all_series", has_region=has_region
-        )
+        estimated_pages = PAGE_ESTIMATOR.estimate_pages("all_series", has_region=has_region)
         PAGE_ESTIMATOR.start(estimated_pages)
 
         try:
             if not return_region:
-                print(
-                    f"Querying all VM series (~{estimated_pages} pages expected)..."
-                )
+                print(f"Querying all VM series (~{estimated_pages} pages expected)...")
 
             # Build minimal query - no productName, no armSkuName
             query = "priceType eq 'Consumption' and serviceName eq 'Virtual Machines' and serviceFamily eq 'Compute'"
@@ -1822,9 +1794,7 @@ def main() -> None:
 
             page_start = time.time()
             params = build_api_params(query, args)
-            json_data = fetch_pricing_data(
-                api_url, params, session, verbose=args.verbose
-            )
+            json_data = fetch_pricing_data(api_url, params, session, verbose=args.verbose)
             PAGE_ESTIMATOR.record_page(time.time() - page_start)
             items = json_data.get("Items", [])
             next_page = json_data.get("NextPageLink", "")
@@ -1832,15 +1802,11 @@ def main() -> None:
 
             while next_page and page_count < max_pages:
                 if not return_region:
-                    progress_msg = PAGE_ESTIMATOR.format_progress(
-                        page_count + 1, estimated_pages
-                    )
+                    progress_msg = PAGE_ESTIMATOR.format_progress(page_count + 1, estimated_pages)
                     print(f"\r{progress_msg}        ", end="", flush=True)
                 try:
                     page_start = time.time()
-                    json_data = fetch_pricing_data(
-                        next_page, {}, session, verbose=args.verbose
-                    )
+                    json_data = fetch_pricing_data(next_page, {}, session, verbose=args.verbose)
                     PAGE_ESTIMATOR.record_page(time.time() - page_start)
                     items.extend(json_data.get("Items", []))
                     next_page = json_data.get("NextPageLink", "")
@@ -1895,7 +1861,7 @@ def main() -> None:
                         continue
 
                     # Filter excluded VM sizes
-                    normalized_sku = arm_sku_name.replace("Standard_", "").lower()
+                    normalized_sku = arm_sku_name.removeprefix("Standard_").lower()
                     if normalized_sku in excluded_vm_sizes:
                         continue
 
@@ -1976,8 +1942,7 @@ def main() -> None:
                 display_data = all_series_data[: args.top]
             if args.estimate_monthly:
                 display_data = [
-                    row[:2] + [f"{float(row[1]) * 730:.2f}"] + row[2:]
-                    for row in display_data
+                    row[:2] + [f"{float(row[1]) * 730:.2f}"] + row[2:] for row in display_data
                 ]
             print(tabulate(display_data, headers=headers, tablefmt="psql"))
         sys.exit(0)
@@ -1991,17 +1956,16 @@ def main() -> None:
             vm_sz = vm_sz.strip()
             if not vm_sz:
                 continue
+            # Strip Standard_ prefix if present; the API filter adds it back
+            vm_sz = vm_sz.removeprefix("Standard_")
             # Check if this VM size is excluded
-            normalized = vm_sz.replace("Standard_", "").lower()
-            if normalized in excluded_vm_sizes:
+            if vm_sz.lower() in excluded_vm_sizes:
                 logging.debug(f"Skipping excluded VM size: {vm_sz}")
                 continue
             extracted_series = extract_series_from_vm_size(vm_sz)
             vm_sizes_list.append((vm_sz, extracted_series))
         if not vm_sizes_list:
-            logging.error(
-                "No valid VM sizes provided in --vm-sizes (all may be excluded)"
-            )
+            logging.error("No valid VM sizes provided in --vm-sizes (all may be excluded)")
             sys.exit(1)
     else:
         # Use legacy sku-pattern and series-pattern
@@ -2061,9 +2025,7 @@ def main() -> None:
     max_pages = 50  # Safety limit per VM size
 
     # Estimate total pages for SKU queries
-    estimated_pages = PAGE_ESTIMATOR.estimate_pages(
-        "multi_sku", vm_count=len(vm_sizes_list)
-    )
+    estimated_pages = PAGE_ESTIMATOR.estimate_pages("multi_sku", vm_count=len(vm_sizes_list))
     PAGE_ESTIMATOR.start(estimated_pages)
 
     try:
@@ -2076,9 +2038,7 @@ def main() -> None:
         for idx, (sku, series) in enumerate(vm_sizes_list):
             if len(vm_sizes_list) > 1 and not return_region:
                 eta = PAGE_ESTIMATOR.get_eta_str(idx, len(vm_sizes_list))
-                print(
-                    f"\n[{idx + 1}/{len(vm_sizes_list)}] Querying {sku} (ETA: {eta})..."
-                )
+                print(f"\n[{idx + 1}/{len(vm_sizes_list)}] Querying {sku} (ETA: {eta})...")
 
             # Build query for this VM size
             query = (
@@ -2120,9 +2080,7 @@ def main() -> None:
             # Initial request
             page_start = time.time()
             params = build_api_params(query, args)
-            json_data = fetch_pricing_data(
-                api_url, params, session, verbose=args.verbose
-            )
+            json_data = fetch_pricing_data(api_url, params, session, verbose=args.verbose)
             PAGE_ESTIMATOR.record_page(time.time() - page_start)
             build_pricing_table(json_data, table_data, non_spot, low_priority)
 
@@ -2132,14 +2090,10 @@ def main() -> None:
             # Follow pagination
             while next_page and page_count < max_pages:
                 if not return_region:
-                    progress_msg = PAGE_ESTIMATOR.format_progress(
-                        page_count + 1, max_pages
-                    )
+                    progress_msg = PAGE_ESTIMATOR.format_progress(page_count + 1, max_pages)
                     print(f"\r{progress_msg}        ", end="", flush=True)
                 page_start = time.time()
-                json_data = fetch_pricing_data(
-                    next_page, {}, session, verbose=args.verbose
-                )
+                json_data = fetch_pricing_data(next_page, {}, session, verbose=args.verbose)
                 PAGE_ESTIMATOR.record_page(time.time() - page_start)
                 next_page = json_data.get("NextPageLink", "")
                 build_pricing_table(json_data, table_data, non_spot, low_priority)
@@ -2165,16 +2119,14 @@ def main() -> None:
             sku = args.sku_pattern.replace("#", str(args.cpu))
             error_msg += f"\n\nSearched for: {sku}"
             if args.cpu > 32:
-                error_msg += f"\n\nNote: B-series VMs max out at 32 vCPUs. For {args.cpu} cores, try:"
                 error_msg += (
-                    "\n  --no-burstable           (search all non-burstable VMs)"
+                    f"\n\nNote: B-series VMs max out at 32 vCPUs. For {args.cpu} cores, try:"
                 )
+                error_msg += "\n  --no-burstable           (search all non-burstable VMs)"
                 error_msg += "\n  --general-compute        (search D and F series)"
                 error_msg += "\n  --sku-pattern D#as_v5    (specific series pattern)"
             else:
-                error_msg += (
-                    "\n\nTry using --no-burstable or --general-compute for more options"
-                )
+                error_msg += "\n\nTry using --no-burstable or --general-compute for more options"
         logging.error(error_msg)
         sys.exit(1)
 
@@ -2184,14 +2136,10 @@ def main() -> None:
     # Filter out excluded regions
     if excluded_regions:
         original_count = len(table_data)
-        table_data = [
-            row for row in table_data if row[3].lower() not in excluded_regions
-        ]
+        table_data = [row for row in table_data if row[3].lower() not in excluded_regions]
         filtered_count = original_count - len(table_data)
         if filtered_count > 0:
-            logging.debug(
-                f"Filtered out {filtered_count} entries from excluded regions"
-            )
+            logging.debug(f"Filtered out {filtered_count} entries from excluded regions")
 
     # Filter by CPU vendor
     has_vendor_filter = (
@@ -2204,9 +2152,7 @@ def main() -> None:
     )
     if has_vendor_filter:
         original_count = len(table_data)
-        table_data = [
-            row for row in table_data if not should_skip_by_vendor(row[0], args)
-        ]
+        table_data = [row for row in table_data if not should_skip_by_vendor(row[0], args)]
         filtered_count = original_count - len(table_data)
         if filtered_count > 0:
             logging.debug(f"Filtered out {filtered_count} entries by CPU vendor")


### PR DESCRIPTION
## Summary
- Fix double Standard_ prefix when --vm-sizes includes Standard_ prefix (e.g. Standard_Standard_D248lds_v7)
- Bump minimum Python version from 3.6 to 3.12+ in README.md and monitor-stddev.md
- Replace .replace("Standard_", "") with .removeprefix("Standard_") across vm-spot-price.py (Python 3.9+ feature)
- Fix mypy errors: blob-storage-price.py type mismatch, monitor-stddev.py impersonate Literal types
- Fix pylint warnings: unused imports in monitor-eviction.py, unused variable in monitor-stddev.py, no-else-return patterns
- All 4 Python files pass mypy (0 errors), pylint (10.00/10 for vm-spot-price, 9.55 overall), bandit (0 medium/high)

## Test plan
- [x] --dry-run with Standard_D248lds_v7 produces correct filter (no doubling)
- [x] --dry-run with D248lds_v7 produces identical output
- [x] Live query with --vm-sizes Standard_D248lds_v7 --return-region returns pricing data
- [x] mypy --ignore-missing-imports passes on all 4 Python files
- [x] pylint passes with improved score
- [x] bandit reports only low-severity expected findings