### PR TITLE
Update trivy-action to 0.35.0, pin all GitHub Actions by SHA

### DIFF
--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run Trivy vulnerability scanner on the cloned repository files
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
-          version: 'v0.61.1'
+          version: 'v0.69.3'
           scan-type: 'fs'
           scanners: 'vuln,misconfig,secret,license'
           ignore-unfixed: true
@@ -41,7 +41,7 @@ jobs:
           ls -lash ${{ env.SARIF_FILE }}
           
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3.28.16
+        uses: github/codeql-action/upload-sarif@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
         with:
           sarif_file: ${{ env.SARIF_FILE }}
 


### PR DESCRIPTION
## Summary
- Update aquasecurity/trivy-action from 0.30.0 to 0.35.0 (Trivy v0.61.1 to v0.69.3)
- Pin all GitHub Actions references by commit SHA instead of version tags for supply chain security
- Version tags retained as comments for readability

### SHA pins
| Action | Version | SHA |
|--------|---------|-----|
| actions/checkout | v4.2.2 | 11bd71901bbe5b1630ceea73d27597364c9af683 |
| aquasecurity/trivy-action | 0.35.0 | 57a97c7e7821a5776cebc9bb87c984fa69cba8f1 |
| github/codeql-action/upload-sarif | v3.28.16 | 28deaeda66b76a05916b6923827895f2b14ab387 |

## Test plan
- [ ] Trivy Analysis workflow runs successfully on this PR
- [ ] SARIF results upload to GitHub Security tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies by pinning commit references and upgraded security scanning tool to a newer version for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->